### PR TITLE
A2: Add CI to run bootstrap + pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+            termite_fieldpack/requirements.txt
+            mite_ecology/requirements.txt
+            fieldgrade_ui/requirements.txt
 
       - name: Bootstrap (Linux)
         if: runner.os == 'Linux'
@@ -30,13 +37,20 @@ jobs:
         run: |
           bash scripts/bootstrap_dev.sh
 
+      - name: Run tests (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          ./.venv/bin/python -m pytest -q
+
       - name: Bootstrap (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/bootstrap_dev.ps1
 
-      - name: Run tests
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          python -m pytest -q
+          .\.venv\Scripts\python -m pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Bootstrap (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          bash scripts/bootstrap_dev.sh
+
+      - name: Bootstrap (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/bootstrap_dev.ps1
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          python -m pytest -q


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

CI:
- Introduce a GitHub Actions workflow that bootstraps the dev environment and runs pytest on Ubuntu and Windows for Python 3.11.