### PR TITLE
A3: Add CI docker/compose build validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Docker build
         shell: bash
         run: |
-          docker build --progress=plain -t fieldgrade:ci .
+          docker build -t fieldgrade:ci .
 
       - name: Compose config + build
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Docker + Compose versions
+        shell: bash
+        run: |
+          docker version
+          docker compose version
+
+      - name: Pre-pull base image (retry)
+        shell: bash
+        run: |
+          set -euo pipefail
+          for i in 1 2 3; do
+            echo "Attempt $i: docker pull python:3.11-slim"
+            if docker pull python:3.11-slim; then
+              exit 0
+            fi
+            sleep $((i * 5))
+          done
+          echo "Base image pull failed after retries" >&2
+          exit 1
+
       - name: Docker build
         shell: bash
         run: |
-          docker build -t fieldgrade:ci .
+          docker build --progress=plain -t fieldgrade:ci .
 
       - name: Compose config + build
         shell: bash
@@ -73,4 +93,4 @@ jobs:
           FG_API_TOKEN: ci_dummy_token
         run: |
           docker compose -f compose.yaml config
-          docker compose -f compose.yaml build
+          docker compose -f compose.yaml build --progress=plain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,25 +62,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Docker + Compose versions
-        shell: bash
-        run: |
-          docker version
-          docker compose version
-
-      - name: Pre-pull base image (retry)
+      - name: Docker + Compose versions (ensure compose)
         shell: bash
         run: |
           set -euo pipefail
-          for i in 1 2 3; do
-            echo "Attempt $i: docker pull python:3.11-slim"
-            if docker pull python:3.11-slim; then
-              exit 0
-            fi
-            sleep $((i * 5))
-          done
-          echo "Base image pull failed after retries" >&2
-          exit 1
+          docker version
+          if docker compose version; then
+            exit 0
+          fi
+          sudo apt-get update
+          sudo apt-get install -y docker-compose-plugin
+          docker compose version
+
+      - name: Pre-pull base image (best-effort)
+        shell: bash
+        run: |
+          # This may fail due to transient network or rate limits; the actual
+          # build step will still surface a real failure if the image can't be pulled.
+          docker pull python:3.11-slim || true
 
       - name: Docker build
         shell: bash
@@ -89,9 +88,7 @@ jobs:
 
       - name: Compose config + build
         shell: bash
-        env:
-          FG_API_TOKEN: ci_dummy_token
         run: |
-          docker compose -f compose.yaml config
+          FG_API_TOKEN=ci_dummy_token docker compose -f compose.yaml config
           # Note: We intentionally do not run `docker compose build` here because it
           # would rebuild the same Dockerfile context and add redundant CI work.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,4 +93,5 @@ jobs:
           FG_API_TOKEN: ci_dummy_token
         run: |
           docker compose -f compose.yaml config
-          docker compose -f compose.yaml build --progress=plain
+          # Note: We intentionally do not run `docker compose build` here because it
+          # would rebuild the same Dockerfile context and add redundant CI work.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,23 @@ jobs:
         shell: pwsh
         run: |
           .\.venv\Scripts\python -m pytest -q
+
+  docker:
+    name: docker build + compose config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker build
+        shell: bash
+        run: |
+          docker build -t fieldgrade:ci .
+
+      - name: Compose config + build
+        shell: bash
+        env:
+          FG_API_TOKEN: ci_dummy_token
+        run: |
+          docker compose -f compose.yaml config
+          docker compose -f compose.yaml build

--- a/resources/.gitkeep
+++ b/resources/.gitkeep
@@ -1,0 +1,3 @@
+# Intentionally empty.
+# This file ensures the `resources/` directory exists in git checkouts.
+# Large/local artifacts under `resources/` are ignored by `.gitignore`.


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

CI:
- Add a CI job that builds the Docker image and validates Docker Compose configuration and build using compose.yaml.