### PR TITLE
Add production compose+Caddy, DB URL prep, and bundle storage adapter

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+{$FIELDGRADE_DOMAIN:localhost} {
+    reverse_proxy web:8787
+}

--- a/MIGRATION_PLAN_B.md
+++ b/MIGRATION_PLAN_B.md
@@ -1,0 +1,3 @@
+# Migration Plan B (moved)
+
+This document moved to: `docs/MIGRATION_PLAN_B.md`

--- a/MIGRATION_PLAN_C.md
+++ b/MIGRATION_PLAN_C.md
@@ -1,0 +1,3 @@
+# Migration Plan C (moved)
+
+This document moved to: `docs/MIGRATION_PLAN_C.md`

--- a/MIGRATION_PLAN_D.md
+++ b/MIGRATION_PLAN_D.md
@@ -1,0 +1,3 @@
+# Migration Plan D (moved)
+
+This document moved to: `docs/MIGRATION_PLAN_D.md`

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -1,0 +1,31 @@
+services:
+  web:
+    restart: always
+    ports: []
+    environment:
+      # Behind TLS termination (Caddy), trust proxy headers.
+      FG_PROXY_HEADERS: "1"
+      FG_FORWARDED_ALLOW_IPS: "*"
+
+  worker:
+    restart: always
+
+  caddy:
+    image: caddy:2
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      # Set this to your public hostname (e.g. fieldgrade.example.com)
+      FIELDGRADE_DOMAIN: "${FIELDGRADE_DOMAIN:-localhost}"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - web
+
+volumes:
+  caddy_data: {}
+  caddy_config: {}

--- a/docs/DEPLOY_PROD_SINGLEHOST.md
+++ b/docs/DEPLOY_PROD_SINGLEHOST.md
@@ -1,0 +1,62 @@
+# Single-host production deployment (Docker Compose + Caddy)
+
+This is the fastest path to a “real web” deployment while keeping Fieldgrade’s strict invariants (bundle bytes are immutable; DSSE/CycloneDX semantics unchanged).
+
+## Prereqs
+
+- A Linux VM or bare-metal host with Docker installed.
+- Ports 80/443 reachable from the internet (for automatic HTTPS).
+- A DNS `A`/`AAAA` record pointing your domain at the host.
+
+## Files
+
+- `compose.yaml` (base)
+- `compose.production.yaml` (production overlay)
+- `Caddyfile` (HTTPS reverse proxy)
+
+## Configure
+
+Create a `.env` file next to `compose.yaml`:
+
+- `FG_API_TOKEN` (required): token required by the API (`X-API-Key` header)
+- `FIELDGRADE_DOMAIN` (recommended): your public hostname (e.g. `fieldgrade.example.com`)
+
+Optional (future-facing knobs):
+
+- `DATABASE_URL`: today must be SQLite (e.g. `sqlite:////app/fieldgrade_ui/runtime/jobs.sqlite`). Postgres is a Phase B change.
+- `FG_BUNDLE_STORE`: `local` (default) or `s3`
+- `FG_S3_BUCKET` (required when `FG_BUNDLE_STORE=s3`): bucket name
+- `FG_S3_PREFIX` (optional): key prefix within the bucket
+
+When `FG_BUNDLE_STORE=s3`, the container uses `boto3` and the standard AWS env vars:
+
+- `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (required for most setups)
+- `AWS_SESSION_TOKEN` (optional; required for some temporary credentials)
+- `AWS_REGION` or `AWS_DEFAULT_REGION` (recommended)
+
+For S3-compatible endpoints (e.g. MinIO), also set:
+
+- `AWS_ENDPOINT_URL` (e.g. `http://minio:9000` inside a Docker network, or a full URL)
+
+## Deploy
+
+From the `fg_next/` directory on the host:
+
+- Build and start:
+  - `docker compose -f compose.yaml -f compose.production.yaml up -d --build`
+
+- Tail logs:
+  - `docker compose logs -f --tail=200`
+
+## Verify
+
+- HTTPS:
+  - Visit `https://$FIELDGRADE_DOMAIN/` (Caddy provisions a TLS cert automatically once DNS and ports are correct).
+
+- API:
+  - `curl -H "X-API-Key: $FG_API_TOKEN" https://$FIELDGRADE_DOMAIN/healthz`
+
+## Notes
+
+- Single-host mode keeps runtime state on the host (named volumes). Back up Docker volumes regularly.
+- For multi-host / “platform” mode, move state to Postgres and bundles/artifacts to object storage (Phases B/C).

--- a/docs/MIGRATION_PLAN_A.md
+++ b/docs/MIGRATION_PLAN_A.md
@@ -1,5 +1,21 @@
 # Migration plan A — “Make it shippable” (preserve determinism + DSSE/CDX semantics)
 
+## Current status (as of 2025-12-31)
+
+The repo has progressed through the Phase A scope below. Multi-tenant SaaS features described in later phases (B–D) are not implemented yet.
+
+Evidence of Phase A work completed:
+
+- **A1 — Repo hygiene and reproducible setup.** Bootstrap + CI were added so `make install` and `make test` can run from a clean environment. CI runs Linux and Windows matrix builds and verifies tests pass.
+- **A2 — Containerization.** `compose.yaml` defines a two-service deployment (`web` FastAPI UI + `worker` job worker) with named volumes for termite and mite runtime/artifact directories. The Dockerfile builds a single Python image containing `termite_fieldpack`, `mite_ecology`, and `fieldgrade_ui`, exposing the API on port 8787.
+- **A3/A4 — Operational endpoints and CI kill-tests.** CI includes a dedicated Docker validation job (installs docker-compose plugin if needed and runs `docker compose config`). Regression tests assert bundle verification fails for corrupted/tampered DSSE and missing CycloneDX SBOMs, and that replay does not mutate bundle ZIP bytes. The DSSE attestation decoder fails when the signature cannot be base64-decoded.
+
+Gaps / remaining work:
+
+- **Phase B — Multi-tenant core.** No Postgres-backed org/project/membership/dataset/run model, migrations, RBAC, API keys, or audit logging; state is still local SQLite job queue + runtime directories. Tenant isolation is not implemented, so the Phase A4 “tenant isolation kill-test” remains not applicable.
+- **Phase C — Pipeline platformisation.** Artifacts remain on local filesystem, verification is still CLI-invoked (no “verify as a service” API), and there is no review queue UI or deterministic server-side “Run” abstraction.
+- **Phase D — Billing and entitlements.** No pricing, Stripe integration, usage metering, or subscription provisioning.
+
 This plan is explicitly constrained by:
 - **Do not break deterministic behavior** for sealing/verification/replay.
 - **Do not change DSSE envelope semantics** or CycloneDX verification expectations.

--- a/docs/MIGRATION_PLAN_B.md
+++ b/docs/MIGRATION_PLAN_B.md
@@ -1,0 +1,56 @@
+# Migration plan B — Multi-tenant core (Postgres + RBAC + API keys)
+
+## Current status (as of 2025-12-31)
+
+Phase B is **not implemented** yet.
+
+- There are no Postgres-backed migrations/models for organisations, projects, memberships, datasets, or runs.
+- There is no RBAC guard layer, API-key system, or audit logging.
+- State remains local (SQLite job queue + runtime/artifact directories), so tenant isolation is not available.
+
+## Scope and non-goals
+
+In scope:
+- Introduce a multi-tenant data model suitable for a hosted web platform.
+- Enforce tenant isolation end-to-end at the API and data access layers.
+
+Out of scope (for Phase B):
+- Billing/Stripe/entitlements (Phase D)
+- Full platformisation of pipelines/object storage (Phase C)
+
+## Goals
+
+- Postgres-backed persistence for tenant-scoped entities.
+- Strong tenant isolation (cross-org access prevention).
+- RBAC and API keys for programmatic access.
+- Audit logging for security-relevant actions.
+
+## Planned work items (placeholders)
+
+- Data model + migrations
+  - [ ] Organisations
+  - [ ] Projects
+  - [ ] Memberships / roles
+  - [ ] Datasets
+  - [ ] Runs
+- AuthN/AuthZ
+  - [ ] RBAC policy model (roles, permissions)
+  - [ ] API-key issuance + rotation
+  - [ ] Request-scoped tenant context
+- Guardrails + observability
+  - [ ] Audit log schema + writer
+  - [ ] Admin-only endpoints (if needed)
+- Kill-tests / acceptance gates
+  - [ ] Tenant isolation kill-test (cross-org access must fail)
+  - [ ] Deterministic/immutability invariants remain enforced
+
+## Exit criteria
+
+- All tenant-scoped requests require an org/project context and are authorization-checked.
+- Postgres migrations run cleanly; CI includes migration/app boot checks.
+- Tenant isolation kill-test is enabled and passing.
+
+## Risks / notes
+
+- Preserve Phase A invariants: bundle bytes remain immutable evidence artifacts; DSSE/CDX semantics unchanged.
+- Ensure queries are deterministic where determinism matters (explicit `ORDER BY`).

--- a/docs/MIGRATION_PLAN_C.md
+++ b/docs/MIGRATION_PLAN_C.md
@@ -1,0 +1,53 @@
+# Migration plan C — Pipeline platformisation (object storage + verify as a service)
+
+## Current status (as of 2025-12-31)
+
+Phase C is **not implemented** yet.
+
+- Bundles and artifacts are stored on the local filesystem.
+- Verification is invoked via CLI; there is no server-side “verify as a service” API.
+- There is no review queue UI and no deterministic server-side “Run” abstraction for analytics.
+
+## Scope and non-goals
+
+In scope:
+- Move artifact/bundle storage from local disk to an object store (S3-compatible).
+- Expose verification via web/API services.
+- Introduce a durable “Run” concept for repeatable analytics.
+
+Out of scope (for Phase C):
+- Billing/Stripe/entitlements (Phase D)
+
+## Goals
+
+- Object storage for bundles/artifacts with hash-addressed immutability guarantees.
+- Server-side verification workflows (API/service) with strict DSSE/CycloneDX checks.
+- A stable “Run” abstraction that supports deterministic replay and auditing.
+
+## Planned work items (placeholders)
+
+- Storage
+  - [ ] Bundle store interface (local dev, S3 prod)
+  - [ ] Artifact store interface (local dev, S3 prod)
+  - [ ] Store raw bytes + content hash; never mutate bytes after upload
+- Verification as a service
+  - [ ] API endpoint(s) for submit/verify
+  - [ ] Background job integration (queue + worker)
+  - [ ] Verification result persistence (status, logs, hashes)
+- Review / workflow
+  - [ ] Review queue model
+  - [ ] Minimal UI surface (placeholder)
+- Determinism guardrails
+  - [ ] Ensure download→hash validation on every read
+  - [ ] Ensure canonical JSON rules are enforced where hashed/signed
+
+## Exit criteria
+
+- Bundles/artifacts can be stored and retrieved via object storage without changing bytes.
+- Verification can be run as a service and yields the same results as CLI.
+- Deterministic replay remains valid; immutability and strict verification tests remain passing.
+
+## Risks / notes
+
+- Treat object storage as untrusted: validate hashes and enforce immutability semantics at read/write boundaries.
+- Keep Phase A invariants intact: DSSE envelope and CycloneDX expectations must not change.

--- a/docs/MIGRATION_PLAN_D.md
+++ b/docs/MIGRATION_PLAN_D.md
@@ -1,0 +1,53 @@
+# Migration plan D — Billing and entitlements (subscriptions + usage metering)
+
+## Current status (as of 2025-12-31)
+
+Phase D is **not implemented** yet.
+
+- There is no pricing/billing code.
+- There is no Stripe integration.
+- There is no usage metering, subscription provisioning, or entitlement enforcement.
+
+## Scope and non-goals
+
+In scope:
+- Subscription lifecycle management.
+- Usage metering and plan entitlements.
+- Enforcing entitlements at API/workflow boundaries.
+
+Out of scope (for Phase D):
+- Major product/UI redesign (keep changes minimal)
+
+## Goals
+
+- A clear plan/entitlement model (free vs paid tiers).
+- Automated subscription provisioning and renewal handling.
+- Usage metering that is auditable and ties back to tenant context.
+
+## Planned work items (placeholders)
+
+- Pricing + plans
+  - [ ] Define plans and entitlements (limits/quotas)
+  - [ ] Persist entitlements per org
+- Billing integration
+  - [ ] Stripe customer + subscription wiring
+  - [ ] Webhook handling (idempotent)
+  - [ ] Billing portal/customer management (placeholder)
+- Usage metering
+  - [ ] Define billable events
+  - [ ] Record usage with tenant attribution
+  - [ ] Aggregation/reporting (placeholder)
+- Enforcement
+  - [ ] Gate operations by entitlement (API + worker)
+  - [ ] Soft/hard limits behavior (placeholder)
+
+## Exit criteria
+
+- Subscriptions can be created/updated/canceled and reflected in entitlements.
+- Usage is metered and can be audited per org.
+- Entitlements are enforced consistently across API and worker workflows.
+
+## Risks / notes
+
+- Avoid introducing nondeterminism into bundle sealing/verification; billing must not affect evidence artifact bytes.
+- Ensure webhook handlers are idempotent and resilient.

--- a/fieldgrade_ui/__main__.py
+++ b/fieldgrade_ui/__main__.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import argparse
-import os
 import ipaddress
+
+from .config import api_token, forwarded_allow_ips, proxy_headers_enabled, ui_host, ui_log_level, ui_port, ui_reload, ui_workers
 
 def main() -> None:
     parser = argparse.ArgumentParser(prog="python -m fieldgrade_ui")
@@ -26,15 +27,15 @@ def main() -> None:
         return
 
     # default: serve
-    host = os.environ.get("FG_HOST") or os.environ.get("FIELDGRADE_UI_HOST", "127.0.0.1")
-    port = int(os.environ.get("FG_PORT") or os.environ.get("FIELDGRADE_UI_PORT", "8787"))
-    workers = int(os.environ.get("FG_WORKERS") or os.environ.get("FIELDGRADE_UI_WORKERS", "1"))
-    log_level = os.environ.get("FG_LOG_LEVEL", "info")
-    reload = os.environ.get("FG_RELOAD", "0") == "1"
+    host = ui_host()
+    port = ui_port()
+    workers = ui_workers()
+    log_level = ui_log_level()
+    reload = ui_reload()
 
     # Security: refuse to bind to a non-loopback interface unless an API token is configured.
     # This prevents path-bearing endpoints from being reachable over the network without auth.
-    tok = (os.environ.get("FG_API_TOKEN") or os.environ.get("FIELDGRADE_UI_API_TOKEN") or "").strip()
+    tok = api_token()
 
     def _is_loopback(h: str) -> bool:
         hs = (h or "").strip()
@@ -67,6 +68,8 @@ def main() -> None:
         workers=workers,
         reload=reload,
         log_level=log_level,
+        proxy_headers=proxy_headers_enabled(),
+        forwarded_allow_ips=forwarded_allow_ips(),
     )
 
 if __name__ == "__main__":

--- a/fieldgrade_ui/config.py
+++ b/fieldgrade_ui/config.py
@@ -1,23 +1,252 @@
 from __future__ import annotations
 
 import os
+import re
+from urllib.parse import unquote, urlparse
 from pathlib import Path
+from typing import Iterable, Optional
+
+"""Fieldgrade UI configuration helpers.
+
+This module is the single source of truth for environment variables used by
+`fieldgrade_ui`.
+
+**Server / API**
+- `FG_HOST` (fallback `FIELDGRADE_UI_HOST`, default `127.0.0.1`): bind host
+- `FG_PORT` (fallback `FIELDGRADE_UI_PORT`, default `8787`): bind port
+- `FG_WORKERS` (fallback `FIELDGRADE_UI_WORKERS`, default `1`): uvicorn workers
+- `FG_LOG_LEVEL` (default `info`): uvicorn log level
+- `FG_RELOAD` (default `0`): set to `1` to enable auto-reload (dev)
+- `FG_API_TOKEN` (fallback `FIELDGRADE_UI_API_TOKEN`, default empty): API auth
+
+**Worker / jobs**
+- `FG_JOBS_DB` (default `{repo}/fieldgrade_ui/runtime/jobs.sqlite`): jobs DB path
+- `FG_ENABLE_WORKER` (default empty): if set, `1` enables embedded worker
+- `FG_WORKER_POLL` (default `1.0`): worker poll interval in seconds
+
+**Database (Phase B prep)**
+- `DATABASE_URL` or `FG_DATABASE_URL`: database URL.
+    - Today only `sqlite://...` is supported; Postgres is a Phase B change.
+
+**Timeouts**
+- `FG_CMD_TIMEOUT_S` (default `600`): subprocess timeout seconds; `0` disables
+
+**Filesystem sandboxes**
+- `FG_UPLOADS_DIR` (fallback `FIELDGRADE_UPLOADS_DIR`): uploads directory override
+- `FG_API_EXTRA_ROOTS`: additional allowed roots for path-bearing endpoints
+    - separated by platform `os.pathsep`; also accepts `:` if unambiguous on Windows
+
+**Upload watcher**
+- `FG_WATCH_STATE` (default `{repo}/fieldgrade_ui/runtime/upload_watch.json`)
+- `FG_WATCH_UPLOADS` (default `0`): set to `1` to enable background upload watcher
+- `FG_WATCH_POLL` (default `2.0`): watcher scan interval
+- `FG_WATCH_LABEL` (default `watch`): label for watcher-enqueued jobs
+
+**Pipeline boundary**
+- `FG_PIPELINE_RUNNER` (default `subprocess`): `subprocess` or `library`
+
+**Reverse proxy / TLS termination**
+- `FG_PROXY_HEADERS` (default `0`): set to `1` when running behind a reverse proxy (Caddy/Nginx)
+- `FG_FORWARDED_ALLOW_IPS` (default `127.0.0.1`): uvicorn forwarded-allow-ips setting
+"""
 
 def repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
+
+def _safe_resolve_path(p: Path) -> Path:
+    p = Path(p).expanduser()
+    try:
+        return p.resolve(strict=False)
+    except Exception:
+        try:
+            return p.resolve()
+        except Exception:
+            return p
+
+
+def env_str(*names: str, default: str = "") -> str:
+    for n in names:
+        v = os.environ.get(n)
+        if v is not None and str(v) != "":
+            return str(v)
+    return default
+
+
+def env_bool(*names: str, default: bool = False) -> bool:
+    v = env_str(*names, default="")
+    if v == "":
+        return bool(default)
+    return str(v).strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def env_int(*names: str, default: int) -> int:
+    v = env_str(*names, default="")
+    if v == "":
+        return int(default)
+    try:
+        return int(str(v).strip())
+    except Exception:
+        return int(default)
+
+
+def env_float(*names: str, default: float) -> float:
+    v = env_str(*names, default="")
+    if v == "":
+        return float(default)
+    try:
+        return float(str(v).strip())
+    except Exception:
+        return float(default)
+
+
+def split_env_path_list(raw: str) -> list[str]:
+    """Split a list of paths from an env var.
+
+    Uses platform `os.pathsep`. For compatibility with older configs, also accepts
+    ':' on platforms where `os.pathsep` is not ':' (e.g. Windows) *only* when the
+    string doesn't look like a drive-letter path list.
+    """
+    s = (raw or "").strip()
+    if not s:
+        return []
+
+    parts = [p.strip() for p in s.split(os.pathsep) if p.strip()]
+    if os.pathsep != ":" and len(parts) == 1 and ":" in s and not re.search(r"[A-Za-z]:[\\/]", s):
+        parts = [p.strip() for p in s.split(":") if p.strip()]
+    return parts
+
+
+def cmd_timeout_s() -> Optional[float]:
+    raw = (os.environ.get("FG_CMD_TIMEOUT_S", "600") or "600").strip()
+    try:
+        v = float(raw)
+    except Exception:
+        v = 600.0
+    if v <= 0:
+        return None
+    return v
+
+
+def ui_host() -> str:
+    return env_str("FG_HOST", "FIELDGRADE_UI_HOST", default="127.0.0.1")
+
+
+def ui_port() -> int:
+    return env_int("FG_PORT", "FIELDGRADE_UI_PORT", default=8787)
+
+
+def ui_workers() -> int:
+    return env_int("FG_WORKERS", "FIELDGRADE_UI_WORKERS", default=1)
+
+
+def ui_log_level() -> str:
+    return env_str("FG_LOG_LEVEL", default="info")
+
+
+def ui_reload() -> bool:
+    return env_bool("FG_RELOAD", default=False)
+
+
+def api_token() -> str:
+    return env_str("FG_API_TOKEN", "FIELDGRADE_UI_API_TOKEN", default="").strip()
+
+
+def database_url() -> str:
+    """Return configured DB URL.
+
+    If DATABASE_URL/FG_DATABASE_URL is not set, this returns a sqlite URL derived
+    from the existing FG_JOBS_DB / default jobs DB path.
+    """
+    raw = env_str("DATABASE_URL", "FG_DATABASE_URL", default="").strip()
+    if raw:
+        return raw
+
+    # Back-compat: derive sqlite URL from legacy path config.
+    p = jobs_db_path()
+    # sqlite:///C:/path/to/file.sqlite on Windows; sqlite:////abs/path on Linux.
+    posix = p.as_posix()
+    if re.match(r"^[A-Za-z]:/", posix):
+        return f"sqlite:///{posix}"
+    return f"sqlite:////{posix.lstrip('/')}"
+
+
+def _sqlite_path_from_url(url: str) -> Optional[Path]:
+    """Parse a sqlite URL into a filesystem path.
+
+    Supported forms:
+    - sqlite:////abs/path/to.db
+    - sqlite:///C:/path/to.db
+    - sqlite:///relative/path.db (treated as relative)
+    """
+    u = (url or "").strip()
+    if not u:
+        return None
+    parsed = urlparse(u)
+    if (parsed.scheme or "").lower() != "sqlite":
+        return None
+
+    # urlparse puts the filesystem path in `path`; decode percent-escapes.
+    raw_path = unquote(parsed.path or "")
+
+    # Handle Windows drive-letter form sqlite:///C:/...
+    if re.match(r"^/[A-Za-z]:/", raw_path):
+        raw_path = raw_path.lstrip("/")
+
+    if not raw_path:
+        return None
+    return _safe_resolve_path(Path(raw_path))
+
+
 def jobs_db_path() -> Path:
+    db_url = env_str("DATABASE_URL", "FG_DATABASE_URL", default="").strip()
+    if db_url:
+        p = _sqlite_path_from_url(db_url)
+        if p is None:
+            raise RuntimeError(
+                "Non-sqlite DATABASE_URL is not supported yet. "
+                "Use sqlite (DATABASE_URL=sqlite://...) for now; Postgres is a Phase B change."
+            )
+        return p
+
     p = os.environ.get("FG_JOBS_DB", "")
     if p:
-        return Path(p)
+        return _safe_resolve_path(Path(p))
     return repo_root() / "fieldgrade_ui" / "runtime" / "jobs.sqlite"
+
+
+def proxy_headers_enabled() -> bool:
+    return env_bool("FG_PROXY_HEADERS", default=False)
+
+
+def forwarded_allow_ips() -> str:
+    return env_str("FG_FORWARDED_ALLOW_IPS", default="127.0.0.1")
+
+
+def uploads_dir(default: Path) -> Path:
+    override = os.environ.get("FG_UPLOADS_DIR") or os.environ.get("FIELDGRADE_UPLOADS_DIR")
+    if override:
+        return _safe_resolve_path(Path(override))
+    return _safe_resolve_path(default)
+
+
+def api_extra_roots() -> list[Path]:
+    raw = (os.environ.get("FG_API_EXTRA_ROOTS") or "").strip()
+    return [_safe_resolve_path(Path(p)) for p in split_env_path_list(raw)]
+
+
+def watch_state_path() -> Path:
+    p = os.environ.get("FG_WATCH_STATE", "")
+    if p:
+        return _safe_resolve_path(Path(p))
+    return repo_root() / "fieldgrade_ui" / "runtime" / "upload_watch.json"
 
 def enable_embedded_worker() -> bool:
     # Safe default: enable embedded worker only when running a single server worker.
     if os.environ.get("FG_ENABLE_WORKER", ""):
         return os.environ.get("FG_ENABLE_WORKER", "0") == "1"
     try:
-        workers = int(os.environ.get("FG_WORKERS") or os.environ.get("FIELDGRADE_UI_WORKERS", "1"))
+        workers = ui_workers()
     except Exception:
         workers = 1
     return workers == 1

--- a/fieldgrade_ui/internal_pipeline.py
+++ b/fieldgrade_ui/internal_pipeline.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import yaml
+
+
+def _safe_resolve(p: Path) -> Path:
+    p = Path(p).expanduser()
+    try:
+        return p.resolve(strict=False)
+    except Exception:
+        try:
+            return p.resolve()
+        except Exception:
+            return p
+
+
+def _expand(s: str) -> str:
+    return os.path.expandvars(os.path.expanduser(str(s)))
+
+
+def _resolve_config_path_value(base_dir: Path, value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    raw = _expand(value)
+    p = Path(raw)
+    if not p.is_absolute():
+        p = base_dir / p
+    return str(_safe_resolve(p))
+
+
+def _set_path(raw: dict[str, Any], key_path: list[str], base_dir: Path) -> None:
+    d: Any = raw
+    for k in key_path[:-1]:
+        if not isinstance(d, dict) or k not in d:
+            return
+        d = d[k]
+    if not isinstance(d, dict):
+        return
+    last = key_path[-1]
+    if last not in d:
+        return
+    d[last] = _resolve_config_path_value(base_dir, d[last])
+
+
+def _load_termite_config(config_path: Path):
+    from termite.config import TermiteConfig
+
+    p = _safe_resolve(Path(config_path))
+    raw = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    if "termite" not in raw:
+        raise ValueError("invalid_config: missing top-level 'termite' key")
+    base_dir = p.parent
+
+    for kp in [
+        ["termite", "runtime_root"],
+        ["termite", "cas_root"],
+        ["termite", "db_path"],
+        ["termite", "bundles_out"],
+        ["termite", "policy_path"],
+        ["termite", "allowlist_path"],
+        ["toolchain", "signing", "private_key_path"],
+        ["toolchain", "signing", "public_key_path"],
+    ]:
+        _set_path(raw, kp, base_dir)
+
+    return TermiteConfig(raw)
+
+
+def _load_ecology_config(config_path: Path):
+    from mite_ecology.config import EcologyConfig
+
+    p = _safe_resolve(Path(config_path))
+    raw = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    if "mite_ecology" not in raw:
+        raise ValueError("invalid_config: missing top-level 'mite_ecology' key")
+    base_dir = p.parent
+
+    for kp in [
+        ["mite_ecology", "runtime_root"],
+        ["mite_ecology", "db_path"],
+        ["mite_ecology", "imports_root"],
+        ["mite_ecology", "exports_root"],
+        ["mite_ecology", "policy_path"],
+        ["mite_ecology", "allowlist_path"],
+        ["mite_ecology", "schemas_dir"],
+    ]:
+        _set_path(raw, kp, base_dir)
+
+    return EcologyConfig(raw)
+
+
+def _default_context_node(con) -> str:
+    row = con.execute("SELECT id FROM nodes WHERE type='Task' LIMIT 1").fetchone()
+    if row:
+        return str(row["id"])
+    row = con.execute("SELECT id FROM nodes LIMIT 1").fetchone()
+    if not row:
+        raise RuntimeError("KG is empty. Import a bundle or ingest nodes first.")
+    return str(row["id"])
+
+
+def run_termite_to_ecology_pipeline_library(
+    repo_root: Path,
+    *,
+    upload_path: Path,
+    label: str,
+    policy_path: Optional[Path] = None,
+    allowlist_path: Optional[Path] = None,
+    termite_config_path: Optional[Path] = None,
+    ecology_config_path: Optional[Path] = None,
+    log: Optional[Callable[[str], None]] = None,
+) -> dict[str, Any]:
+    """Run the termite->ecology pipeline in-process (no subprocess).
+
+    This is intended as a Phase A5 boundary-hardening step. It preserves existing
+    semantics by reusing the same underlying library calls as the CLIs.
+    """
+
+    repo_root = _safe_resolve(repo_root)
+    upload_path = _safe_resolve(upload_path)
+    if not upload_path.exists():
+        raise FileNotFoundError(str(upload_path))
+
+    # Resolve config paths
+    if termite_config_path is None:
+        termite_config_path = repo_root / "termite_fieldpack" / "config" / "termite.yaml"
+    if ecology_config_path is None:
+        ecology_config_path = repo_root / "mite_ecology" / "configs" / "ecology.yaml"
+
+    t_cfg = _load_termite_config(termite_config_path)
+    e_cfg = _load_ecology_config(ecology_config_path)
+
+    # termite imports
+    from termite.cas import CAS
+    from termite.db import connect as t_connect
+    from termite.ingest import ingest_path
+    from termite.provenance import Provenance
+    from termite.bundle import SealInputs, build_bundle
+    from termite.policy import load_policy, canonical_hash_dict
+    from termite.verify import verify_bundle
+    from termite.replay import replay_bundle
+
+    # mite_ecology imports
+    from mite_ecology.db import connect as e_connect, init_db as e_init_db
+    from mite_ecology.bundle_accept import accept_termite_bundle, AcceptPolicy
+    from mite_ecology.replay import replay_verify
+    from mite_ecology.kg import KnowledgeGraph
+    from mite_ecology.auto import autorun, AutoRunConfig
+    from mite_ecology.hashutil import sha256_str, canonical_json
+
+    # ------------------------
+    # 1) termite ingest
+    # ------------------------
+    if log:
+        log(f"pipeline(lib): upload_path={upload_path}")
+        log(f"pipeline(lib): label={label}")
+
+    cas = CAS(t_cfg.cas_root)
+    cas.init()
+    t_con = t_connect(t_cfg.db_path)
+    prov = Provenance(t_cfg.toolchain_id)
+    ingest_res = ingest_path(
+        t_con,
+        cas,
+        prov,
+        upload_path,
+        max_bytes=t_cfg.max_bytes,
+        extract_text=t_cfg.extract_text,
+        chunk_chars=t_cfg.chunk_chars,
+        overlap_chars=t_cfg.overlap_chars,
+        min_chunk_chars=t_cfg.min_chunk_chars,
+    )
+
+    # ------------------------
+    # 2) termite seal
+    # ------------------------
+    pol_path = _safe_resolve(policy_path) if policy_path is not None else t_cfg.policy_path
+    allow_path = _safe_resolve(allowlist_path) if allowlist_path is not None else t_cfg.allowlist_path
+
+    pol = load_policy(pol_path)
+    allow = yaml.safe_load(allow_path.read_text(encoding="utf-8")) or {}
+    allow["_base_dir"] = str(allow_path.resolve().parent)
+    allow_for_hash = {k: v for k, v in allow.items() if k != "_base_dir"}
+
+    inp = SealInputs(
+        toolchain_id=t_cfg.toolchain_id,
+        cas=cas,
+        db_path=t_cfg.db_path,
+        bundles_out=t_cfg.bundles_out,
+        signing_priv=t_cfg.signing_private_key_path,
+        signing_pub=t_cfg.signing_public_key_path,
+        signing_enabled=t_cfg.signing_enabled,
+        include_raw=t_cfg.include_raw,
+        include_extract=t_cfg.include_extract,
+        include_aux=t_cfg.include_aux,
+        include_provenance=t_cfg.include_provenance,
+        include_sbom=t_cfg.include_sbom,
+        include_kg_delta=t_cfg.include_kg_delta,
+        deterministic_zip=t_cfg.deterministic_zip,
+        policy_hash=pol.canonical_hash(),
+        allowlist_hash=canonical_hash_dict(allow_for_hash),
+    )
+    bundle_path = build_bundle(inp, label=label)
+
+    # ------------------------
+    # 3) termite verify + replay
+    # ------------------------
+    vr = verify_bundle(bundle_path, policy=pol, allowlist=allow)
+    if not vr.ok:
+        raise RuntimeError(f"termite verify not ok: {vr.__dict__}")
+
+    rs = replay_bundle(bundle_path, policy=pol, allowlist=allow)
+    if not rs.ok:
+        raise RuntimeError(f"termite replay not ok: {rs.__dict__}")
+
+    # ------------------------
+    # 4) mite_ecology init (schema)
+    # ------------------------
+    e_cfg.runtime_root.mkdir(parents=True, exist_ok=True)
+    e_cfg.imports_root.mkdir(parents=True, exist_ok=True)
+    e_cfg.exports_root.mkdir(parents=True, exist_ok=True)
+    e_con = e_connect(e_cfg.db_path)
+    e_schema = repo_root / "mite_ecology" / "sql" / "schema.sql"
+    e_init_db(e_con, e_schema)
+    e_con.close()
+
+    # ------------------------
+    # 5) import bundle (idempotent)
+    # ------------------------
+    accept_termite_bundle(
+        e_cfg.db_path,
+        bundle_path,
+        policy_path=e_cfg.policy_path,
+        allowlist_path=e_cfg.allowlist_path,
+        accept_policy=AcceptPolicy(
+            max_ops=e_cfg.max_bundle_ops,
+            max_new_nodes=getattr(e_cfg, "max_bundle_new_nodes", 2000),
+            max_new_edges=getattr(e_cfg, "max_bundle_new_edges", 10000),
+        ),
+        override_mode=None,
+        actor=None,
+        notes=None,
+        idempotent=True,
+    )
+
+    # ------------------------
+    # 6) auto-run (same defaults as CLI)
+    # ------------------------
+    e_con = e_connect(e_cfg.db_path)
+    kg = KnowledgeGraph(e_con)
+    context = _default_context_node(e_con)
+    ar = AutoRunConfig(
+        cycles=5,
+        hops=e_cfg.hops,
+        feature_dim=e_cfg.feature_dim,
+        top_attention_edges=64,
+        motif_limit=24,
+        population=32,
+        generations=12,
+        llm_mode="off",
+        notes="",
+    )
+    rep = autorun(kg, context_node_id=context, cfg=ar)
+    out = e_cfg.runtime_root / "reports"
+    out.mkdir(parents=True, exist_ok=True)
+    rp = out / f"autorun_{sha256_str(canonical_json(rep))[:16]}.json"
+    rp.write_text(canonical_json(rep), encoding="utf-8")
+    e_con.close()
+
+    # ------------------------
+    # 7) replay-verify
+    # ------------------------
+    replay_json = replay_verify(e_cfg.db_path)
+    if not replay_json.get("match"):
+        raise RuntimeError(f"mite_ecology replay-verify mismatch: {replay_json}")
+    if not replay_json.get("kg_deltas_chain_ok") or not replay_json.get("ingested_chain_ok"):
+        raise RuntimeError(f"mite_ecology replay-verify chain failed: {replay_json}")
+
+    return {
+        "ingest": asdict(ingest_res),
+        "bundle_path": str(bundle_path),
+        "verify": vr.__dict__,
+        "replay_verify": replay_json,
+    }

--- a/fieldgrade_ui/requirements.txt
+++ b/fieldgrade_ui/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.110.0
 uvicorn>=0.23.0
 python-multipart>=0.0.9
+boto3>=1.34.0

--- a/fieldgrade_ui/storage.py
+++ b/fieldgrade_ui/storage.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Protocol
+
+
+class BlobStore(Protocol):
+    def put_bytes(self, key: str, data: bytes, *, content_type: Optional[str] = None) -> str:
+        """Store bytes under a key and return a stable URI (e.g. s3://... or file://...)."""
+
+        ...
+
+    def exists(self, key: str) -> bool:
+        """Return True if key exists."""
+
+        ...
+
+
+def _sha256_bytes(data: bytes) -> str:
+    h = hashlib.sha256()
+    h.update(data)
+    return h.hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@dataclass(frozen=True)
+class StoredBlob:
+    key: str
+    uri: str
+    sha256: str
+
+
+class LocalDirBlobStore:
+    """A minimal local blob store rooted at a directory.
+
+    This is primarily a dev/test implementation and a shape-compatible stand-in
+    for S3. It never mutates the source file; it only writes a new object.
+    """
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+
+    def _path_for_key(self, key: str) -> Path:
+        safe_key = key.lstrip("/")
+        p = (self.root / safe_key).resolve()
+        # best-effort safety: ensure key doesn't escape root
+        if self.root.resolve() not in p.parents and p != self.root.resolve():
+            raise ValueError(f"invalid_key_escape: {key}")
+        return p
+
+    def put_bytes(self, key: str, data: bytes, *, content_type: Optional[str] = None) -> str:
+        p = self._path_for_key(key)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+        return f"file://{p.as_posix()}"
+
+    def exists(self, key: str) -> bool:
+        return self._path_for_key(key).exists()
+
+
+class S3BlobStore:
+    """S3-compatible blob store.
+
+    Requires `boto3` to be installed in the environment/image.
+    """
+
+    def __init__(self, *, bucket: str, prefix: str = ""):
+        self.bucket = bucket
+        self.prefix = (prefix or "").lstrip("/")
+
+        try:
+            import boto3  # type: ignore
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError(
+                "S3BlobStore requires boto3. Install it in the image or set FG_BUNDLE_STORE=local."
+            ) from e
+
+        self._s3 = boto3.client("s3")
+
+    def _key(self, key: str) -> str:
+        k = key.lstrip("/")
+        return f"{self.prefix}{k}" if self.prefix else k
+
+    def put_bytes(self, key: str, data: bytes, *, content_type: Optional[str] = None) -> str:
+        k = self._key(key)
+        extra = {}
+        if content_type:
+            extra["ContentType"] = content_type
+        self._s3.put_object(Bucket=self.bucket, Key=k, Body=data, **extra)
+        return f"s3://{self.bucket}/{k}"
+
+    def exists(self, key: str) -> bool:
+        k = self._key(key)
+        try:
+            self._s3.head_object(Bucket=self.bucket, Key=k)
+            return True
+        except Exception:
+            return False
+
+
+def bundle_store_backend() -> str:
+    return (os.environ.get("FG_BUNDLE_STORE") or "local").strip().lower()
+
+
+def _default_local_store_root(repo_root: Path) -> Path:
+    return repo_root / "fieldgrade_ui" / "runtime" / "object_store"
+
+
+def get_blob_store(repo_root: Path) -> BlobStore:
+    backend = bundle_store_backend()
+    if backend in ("local", "filesystem", "fs"):
+        root = Path(os.environ.get("FG_OBJECT_STORE_ROOT") or _default_local_store_root(repo_root))
+        return LocalDirBlobStore(root)
+
+    if backend in ("s3", "minio"):
+        bucket = (os.environ.get("FG_S3_BUCKET") or "").strip()
+        if not bucket:
+            raise RuntimeError("missing FG_S3_BUCKET for FG_BUNDLE_STORE=s3")
+        prefix = (os.environ.get("FG_S3_PREFIX") or "").strip()
+        return S3BlobStore(bucket=bucket, prefix=prefix)
+
+    raise RuntimeError(f"unknown FG_BUNDLE_STORE={backend!r}")
+
+
+def publish_bundle_if_configured(repo_root: Path, bundle_path: Path) -> Optional[StoredBlob]:
+    """Optionally publish a sealed bundle to object storage.
+
+    Default behavior is a no-op (`FG_BUNDLE_STORE=local`). When enabled, the
+    bundle is uploaded under a hash-addressed key to preserve immutability.
+    """
+
+    backend = bundle_store_backend()
+    if backend in ("local", "filesystem", "fs"):
+        return None
+
+    data = bundle_path.read_bytes()
+    sha = _sha256_bytes(data)
+    key = f"bundles/{sha}.zip"
+
+    store = get_blob_store(repo_root)
+    uri = store.put_bytes(key, data, content_type="application/zip")
+    if not store.exists(key):
+        raise RuntimeError("bundle_store_write_failed")
+
+    return StoredBlob(key=key, uri=uri, sha256=sha)

--- a/fieldgrade_ui/watcher.py
+++ b/fieldgrade_ui/watcher.py
@@ -1,22 +1,15 @@
 from __future__ import annotations
 
 import json
-import os
 import time
 from pathlib import Path
 from typing import Dict, Optional
 
-from .config import jobs_db_path, repo_root
+from .config import jobs_db_path, watch_state_path
 from .jobs import create_job
 
-def _state_path() -> Path:
-    p = os.environ.get("FG_WATCH_STATE", "")
-    if p:
-        return Path(p)
-    return repo_root() / "fieldgrade_ui" / "runtime" / "upload_watch.json"
-
 def load_state() -> Dict[str, dict]:
-    sp = _state_path()
+    sp = watch_state_path()
     if sp.exists():
         try:
             return json.loads(sp.read_text())
@@ -25,7 +18,7 @@ def load_state() -> Dict[str, dict]:
     return {}
 
 def save_state(state: Dict[str, dict]) -> None:
-    sp = _state_path()
+    sp = watch_state_path()
     sp.parent.mkdir(parents=True, exist_ok=True)
     sp.write_text(json.dumps(state, indent=2))
 

--- a/mite_ecology/tests/test_a5_ui_pipeline_library_runner.py
+++ b/mite_ecology/tests/test_a5_ui_pipeline_library_runner.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def test_a5_inprocess_pipeline_runner_smoke(tmp_path: Path):
+    """A5 boundary hardening: run the UI pipeline in-process (no subprocess).
+
+    Uses temporary configs + runtime dirs so the test is hermetic.
+    """
+
+    # Ensure termite_fieldpack is importable (monorepo-style)
+    sys.path.insert(0, str(_repo_root() / "termite_fieldpack"))
+
+    from fieldgrade_ui.internal_pipeline import run_termite_to_ecology_pipeline_library
+
+    from termite.cas import CAS
+    from termite.db import connect as t_connect, init_db as t_init_db
+    from termite.signing import load_or_create
+
+    repo = _repo_root()
+
+    # ------------------------
+    # Build hermetic termite runtime + config
+    # ------------------------
+    t_root = tmp_path / "termite"
+    t_runtime = t_root / "runtime"
+    t_cas_root = t_runtime / "cas"
+    t_db = t_runtime / "termite.sqlite"
+    t_bundles_out = t_root / "artifacts" / "bundles_out"
+    t_keys = t_runtime / "keys"
+    priv = t_keys / "toolchain_ed25519.pem"
+    pub = t_keys / "toolchain_ed25519.pub"
+
+    t_keys.mkdir(parents=True, exist_ok=True)
+    load_or_create(priv, pub)
+
+    # termite schema
+    cas = CAS(t_cas_root)
+    cas.init()
+    con = t_connect(t_db)
+    t_init_db(con, repo / "termite_fieldpack" / "sql" / "schema.sql")
+    con.close()
+
+    # policy + allowlist
+    policy_path = t_root / "meap.yaml"
+    allowlist_path = t_root / "allowlist.yaml"
+    policy_obj = {
+        "meap_v1": {
+            "policy_id": "TEST_MEAP",
+            "policy_version": 1,
+            "mode": "AUTO_MERGE",
+            "thresholds": {
+                "max_bundle_mb": 25,
+                "max_files_in_bundle": 200,
+                "require_signature": True,
+                "require_manifest_hashes": True,
+                "require_deterministic_bundle_hash": True,
+                "require_policy_hash_match": True,
+                "require_allowlist_hash_match": True,
+                "require_dsse_attestations": True,
+                "require_cyclonedx_sbom": True,
+            },
+            "protected_paths": [],
+        }
+    }
+    policy_path.write_text(yaml.safe_dump(policy_obj, sort_keys=True), encoding="utf-8")
+
+    allowlist_obj = {
+        "allowlist": {
+            "toolchain_ids": [
+                {
+                    "id": "TEST_TOOLCHAIN",
+                    "pubkey_path": str(pub),
+                }
+            ]
+        }
+    }
+    allowlist_path.write_text(yaml.safe_dump(allowlist_obj, sort_keys=True), encoding="utf-8")
+
+    termite_cfg_path = t_root / "termite.yaml"
+    termite_cfg = {
+        "termite": {
+            "runtime_root": str(t_runtime),
+            "cas_root": str(t_cas_root),
+            "db_path": str(t_db),
+            "bundles_out": str(t_bundles_out),
+            "policy_path": str(policy_path),
+            "allowlist_path": str(allowlist_path),
+            "offline_mode": True,
+            "network_policy": "deny_by_default",
+        },
+        "toolchain": {
+            "toolchain_id": "TEST_TOOLCHAIN",
+            "signing": {
+                "enabled": True,
+                "algorithm": "ed25519",
+                "private_key_path": str(priv),
+                "public_key_path": str(pub),
+            },
+        },
+        "ingest": {
+            "max_bytes": 5_000_000,
+            "extract_text": True,
+            "chunking": {"chunk_chars": 200, "overlap_chars": 20, "min_chunk_chars": 50},
+        },
+        "seal": {
+            "include_raw_blobs": True,
+            "include_extracted_blobs": True,
+            "include_aux": True,
+            "include_provenance": True,
+            "include_sbom": True,
+            "include_kg_delta": True,
+            "deterministic_zip": True,
+        },
+    }
+    termite_cfg_path.write_text(yaml.safe_dump(termite_cfg, sort_keys=True), encoding="utf-8")
+
+    # A tiny upload
+    upload = tmp_path / "upload.txt"
+    upload.write_text("hello world\n", encoding="utf-8")
+
+    # ------------------------
+    # Build hermetic ecology runtime + config
+    # ------------------------
+    e_root = tmp_path / "ecology"
+    e_root.mkdir(parents=True, exist_ok=True)
+    e_runtime = e_root / "runtime"
+    e_db = e_runtime / "mite_ecology.sqlite"
+    e_imports = e_runtime / "imports"
+    e_exports = e_root / "artifacts" / "export"
+
+    ecology_cfg_path = e_root / "ecology.yaml"
+    ecology_cfg = {
+        "mite_ecology": {
+            "runtime_root": str(e_runtime),
+            "db_path": str(e_db),
+            "imports_root": str(e_imports),
+            "exports_root": str(e_exports),
+            "policy_path": str(policy_path),
+            "allowlist_path": str(allowlist_path),
+            "schemas_dir": str(repo / "schemas"),
+            "max_bundle_ops": 200_000,
+        },
+        "embedding": {"hops": 2, "feature_dim": 16, "normalize": True},
+        "gat": {"alpha": 0.2, "top_edges": 16},
+        "memoga": {"population": 12, "generations": 6, "elite_k": 3, "mutation_rate": 0.3, "crossover_rate": 0.5, "max_nodes_per_genome": 24, "max_edges_per_genome": 40},
+        "accept": {"max_new_nodes": 2000, "max_new_edges": 10000},
+    }
+    ecology_cfg_path.write_text(yaml.safe_dump(ecology_cfg, sort_keys=True), encoding="utf-8")
+
+    res = run_termite_to_ecology_pipeline_library(
+        repo,
+        upload_path=upload,
+        label="a5",
+        termite_config_path=termite_cfg_path,
+        ecology_config_path=ecology_cfg_path,
+    )
+
+    assert res["verify"]["ok"] is True
+    assert res["replay_verify"]["match"] is True
+    assert Path(res["bundle_path"]).exists()


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Introduce centralized configuration helpers, optional object storage publishing, and production-ready deployment scaffolding for Fieldgrade UI.

New Features:
- Add internal in-process pipeline runner option selectable via FG_PIPELINE_RUNNER for termite-to-ecology workflows.
- Introduce optional bundle publishing to a pluggable blob store backend with S3 support and associated configuration.
- Add Docker Compose production overlay and Caddy reverse-proxy configuration for single-host HTTPS deployment.

Enhancements:
- Centralize environment-variable based configuration for server, database, timeouts, paths, and reverse-proxy settings.
- Wire proxy header handling into the uvicorn startup path and simplify watcher and worker polling configuration usage.
- Refactor uploads directory and watcher state path resolution to share common helpers and improve path safety.

Build:
- Add boto3 dependency for S3-backed bundle storage and publishing.

Deployment:
- Add compose.production.yaml overlay to run web and worker services with Caddy TLS termination in production.

Documentation:
- Document current Phase A status and future Phase B–D migration plans, including single-host production deployment instructions and S3 configuration.
- Add top-level stubs pointing to the new migration plan documents for phases B–D.

Tests:
- Add smoke test ensuring the in-process pipeline runner executes end-to-end with hermetic termite and ecology configs.