### PR TITLE
deploy: compose overlays + required env + healthchecks

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,9 @@
+# Example environment for local development (no TLS termination)
+# Copy to .env and edit.
+
+FG_API_TOKEN=dev-local-token
+
+# Optional tuning
+FG_MAX_UPLOAD_BYTES=0
+FG_CMD_TIMEOUT_S=600
+FG_WORKER_POLL=1.0

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,30 @@
+# Example environment for single-host production (Caddy TLS termination)
+# Copy to .env and edit. Do NOT commit real secrets.
+
+# Core
+FG_API_TOKEN=REPLACE_WITH_LONG_RANDOM
+FIELDGRADE_DOMAIN=fieldgrade.example.com
+
+# Proxy correctness (behind Caddy)
+FG_PROXY_HEADERS=1
+# Set to trusted proxy IPs/CIDRs.
+# Recommended: set this to your Docker network subnet (CIDR), e.g. 172.18.0.0/16.
+# Discover it on the host:
+#   docker network inspect fg_next_default --format '{{(index .IPAM.Config 0).Subnet}}'
+# Note: the network exists after the stack is brought up at least once, and may be named <compose-project>_default.
+FG_FORWARDED_ALLOW_IPS=REPLACE_WITH_DOCKER_NETWORK_CIDR
+
+# Optional: bundle/object storage
+# FG_BUNDLE_STORE=local
+# FG_BUNDLE_STORE=s3
+# FG_S3_BUCKET=your-bucket
+# FG_S3_PREFIX=fieldgrade
+
+# AWS credentials for boto3 (when FG_BUNDLE_STORE=s3)
+# AWS_ACCESS_KEY_ID=...
+# AWS_SECRET_ACCESS_KEY=...
+# AWS_DEFAULT_REGION=...
+# AWS_SESSION_TOKEN=...   # only for temporary creds
+
+# S3-compatible endpoints (MinIO/etc)
+# AWS_ENDPOINT_URL=http://minio:9000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,50 @@ on:
   pull_request:
 
 jobs:
+  hygiene:
+    name: hygiene (no tracked junk)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fail if build/runtime junk is tracked
+        shell: bash
+        run: |
+          set -euo pipefail
+          bad_paths_regex='(^|/)\.venv/|(^|/)venv/|(^|/)__pycache__/|(^|/)\.pytest_cache/|\.egg-info/'
+          if git ls-files | grep -E "$bad_paths_regex" -n; then
+            echo "ERROR: build/runtime junk appears in tracked paths (see above)." >&2
+            exit 1
+          fi
+
+  docker-prod-config:
+    name: docker compose config (prod overlay)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker + Compose versions (ensure compose)
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker version
+          if docker compose version; then
+            exit 0
+          fi
+          sudo apt-get update
+          sudo apt-get install -y docker-compose-plugin
+          docker compose version
+
+      - name: Compose config (prod overlay)
+        shell: bash
+        run: |
+          FG_API_TOKEN=ci_dummy_token \
+          FIELDGRADE_DOMAIN=ci.example.invalid \
+          FG_FORWARDED_ALLOW_IPS=127.0.0.1 \
+          docker compose -f compose.yaml -f compose.production.yaml config
+
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -90,5 +134,6 @@ jobs:
         shell: bash
         run: |
           FG_API_TOKEN=ci_dummy_token docker compose -f compose.yaml config
+          FG_API_TOKEN=ci_dummy_token docker compose -f compose.yaml -f compose.dev.yaml config
           # Note: We intentionally do not run `docker compose build` here because it
           # would rebuild the same Dockerfile context and add redundant CI work.

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv/
 env/
 venv/
 ENV/

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,3 @@
-{$FIELDGRADE_DOMAIN:localhost} {
+{$FIELDGRADE_DOMAIN} {
     reverse_proxy web:8787
 }

--- a/README.md
+++ b/README.md
@@ -153,7 +153,28 @@ Or run everything in one command:
 ## Platform guides
 
 - Android (Termux): see `TERMUX.md`
-- Windows laptop: see `WINDOWS.md` (WSL2 recommended)
+- Windows laptop guide — see `WINDOWS.md` (WSL2 recommended)
+
+## Deployment (Docker Compose)
+
+This repo uses Docker Compose file stacking for dev vs production.
+
+- Local dev (exposes `http://127.0.0.1:8787` directly):
+   - `docker compose -f compose.yaml -f compose.dev.yaml up -d --build`
+
+- Single-host production (Caddy TLS termination; do not expose `8787` directly):
+   - `docker compose -f compose.yaml -f compose.production.yaml up -d --build`
+   - See `docs/DEPLOY_PROD_SINGLEHOST.md` and `docs/DEPLOY_CHECKLIST.md`.
+
+For production proxy header trust, prefer trusting only the Docker network CIDR (instead of `*`):
+
+- Bring the stack up once so the network exists.
+- Get the subnet CIDR:
+   - `docker network inspect fg_next_default --format '{{(index .IPAM.Config 0).Subnet}}'`
+- Set:
+   - `FG_FORWARDED_ALLOW_IPS=<that CIDR>` (example: `172.18.0.0/16`)
+- If the network name differs, it’s usually `<project>_default`; discover via:
+   - `docker network ls | grep _default`
 
 
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,4 @@
+services:
+  web:
+    ports:
+      - "8787:8787"

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -1,11 +1,11 @@
 services:
   web:
     restart: always
-    ports: []
     environment:
       # Behind TLS termination (Caddy), trust proxy headers.
       FG_PROXY_HEADERS: "1"
-      FG_FORWARDED_ALLOW_IPS: "*"
+      # Explicitly set this; avoid '*' unless you're certain only the proxy can reach the app.
+      FG_FORWARDED_ALLOW_IPS: "${FG_FORWARDED_ALLOW_IPS:?set FG_FORWARDED_ALLOW_IPS in .env}"
 
   worker:
     restart: always
@@ -18,7 +18,7 @@ services:
       - "443:443"
     environment:
       # Set this to your public hostname (e.g. fieldgrade.example.com)
-      FIELDGRADE_DOMAIN: "${FIELDGRADE_DOMAIN:-localhost}"
+      FIELDGRADE_DOMAIN: "${FIELDGRADE_DOMAIN:?set FIELDGRADE_DOMAIN in .env}"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,8 +4,12 @@ services:
       context: .
       dockerfile: Dockerfile
     command: ["python", "-m", "fieldgrade_ui", "serve"]
-    ports:
-      - "8787:8787"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import sys, urllib.request; urllib.request.urlopen('http://127.0.0.1:8787/healthz', timeout=2).read(); sys.exit(0)"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
     environment:
       FG_HOST: "0.0.0.0"
       FG_PORT: "8787"

--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -1,0 +1,69 @@
+# Deploy checklist (single-host v0)
+
+This checklist is the minimal “deploy parity” guardrail for bringing up Fieldgrade as a real single-host web service using Docker Compose + Caddy TLS termination.
+
+## 1) Clean repo sanity
+
+- Confirm you are on the latest `main`:
+  - `git checkout main`
+  - `git pull --ff-only origin main`
+
+- Confirm you are deploying from a clean tree:
+  - `git status --porcelain=v1` (should be empty)
+
+## 2) Environment (no defaults)
+
+Create `.env` next to `compose.yaml` (start from `.env.production.example`):
+
+- `FG_API_TOKEN=<long-random>`
+- `FIELDGRADE_DOMAIN=<your.domain>`
+- `FG_PROXY_HEADERS=1`
+- `FG_FORWARDED_ALLOW_IPS=<trusted proxy IPs/CIDRs>`
+
+Recommended: set `FG_FORWARDED_ALLOW_IPS` to the Docker network subnet (CIDR) so only in-network traffic is trusted.
+
+- Discover on host:
+  - `docker network inspect fg_next_default --format '{{(index .IPAM.Config 0).Subnet}}'`
+
+Note: the network exists after the stack is brought up at least once, and the name is usually `<compose-project>_default`.
+
+Optional bundle/object storage:
+
+- `FG_BUNDLE_STORE=local|s3`
+- If `s3`: `FG_S3_BUCKET=...` (+ optional `FG_S3_PREFIX=...`)
+- AWS env vars for `boto3`: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` (and optionally `AWS_SESSION_TOKEN`)
+- S3-compatible endpoints (MinIO/etc): `AWS_ENDPOINT_URL=...`
+
+## 3) Compose validation (must pass)
+
+- Render base + production overlay:
+  - `docker compose -f compose.yaml -f compose.production.yaml config`
+
+- Build + start:
+  - `docker compose -f compose.yaml -f compose.production.yaml up -d --build`
+
+- Logs (first boot):
+  - `docker compose logs -f --tail=200`
+
+- Health:
+  - `docker compose ps` should show `web` as `healthy`.
+
+## 4) Live proof checks (external)
+
+From a machine outside the VPS (your laptop):
+
+- `https://$FIELDGRADE_DOMAIN/healthz`
+- `https://$FIELDGRADE_DOMAIN/readyz`
+
+If scheme/redirect behavior is correct (no `http://` confusion), proxy headers are configured correctly.
+
+## 5) Minimum ops (v0 survivability)
+
+- Backups: all state is in Docker named volumes (including the SQLite jobs DB).
+- Restarts: `compose.production.yaml` sets `restart: always`.
+
+## 6) Rollback
+
+- Revert to a known-good commit:
+  - `git checkout <sha>`
+  - `docker compose -f compose.yaml -f compose.production.yaml up -d --build`

--- a/docs/DEPLOY_PROD_SINGLEHOST.md
+++ b/docs/DEPLOY_PROD_SINGLEHOST.md
@@ -11,6 +11,7 @@ This is the fastest path to a “real web” deployment while keeping Fieldgrade
 ## Files
 
 - `compose.yaml` (base)
+- `compose.dev.yaml` (dev-only override; exposes `8787` on the host)
 - `compose.production.yaml` (production overlay)
 - `Caddyfile` (HTTPS reverse proxy)
 
@@ -18,8 +19,20 @@ This is the fastest path to a “real web” deployment while keeping Fieldgrade
 
 Create a `.env` file next to `compose.yaml`:
 
+Tip: start from `.env.production.example` and edit.
+
 - `FG_API_TOKEN` (required): token required by the API (`X-API-Key` header)
-- `FIELDGRADE_DOMAIN` (recommended): your public hostname (e.g. `fieldgrade.example.com`)
+- `FIELDGRADE_DOMAIN` (required): your public hostname (e.g. `fieldgrade.example.com`)
+
+Behind Caddy (TLS termination), configure proxy header trust explicitly:
+
+- `FG_PROXY_HEADERS=1`
+- `FG_FORWARDED_ALLOW_IPS` (required): trusted IPs/CIDRs for forwarded headers
+  - Recommended: set this to your Docker network subnet (CIDR) so only in-network traffic is trusted.
+  - After the stack has been brought up at least once (so the network exists), find the subnet with:
+    - `docker network inspect fg_next_default --format '{{(index .IPAM.Config 0).Subnet}}'`
+  - If your compose project name differs, the network will be `<project>_default`. To discover it:
+    - `docker network ls | grep _default`
 
 Optional (future-facing knobs):
 
@@ -45,8 +58,15 @@ From the `fg_next/` directory on the host:
 - Build and start:
   - `docker compose -f compose.yaml -f compose.production.yaml up -d --build`
 
+For local dev (direct host port, no Caddy):
+
+- `docker compose -f compose.yaml -f compose.dev.yaml up -d --build`
+
 - Tail logs:
   - `docker compose logs -f --tail=200`
+
+- Health:
+  - `docker compose ps` should show `web` as `healthy` (the container healthcheck hits `/healthz`).
 
 ## Verify
 


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Set up Docker Compose overlays and stricter production configuration, add container healthchecks, and document a single-host deployment path with Caddy, while tightening CI hygiene checks.

New Features:
- Introduce a dev-only Docker Compose overlay that exposes the app on the host for local development.
- Add container healthchecks for the web service using the /healthz endpoint.

Enhancements:
- Require explicit FIELDGRADE_DOMAIN and FG_FORWARDED_ALLOW_IPS values via the production .env, removing permissive defaults for proxy and domain configuration.

CI:
- Add a hygiene job to fail CI when build/runtime junk is tracked in git.
- Add CI checks to render Docker Compose configs for both production and dev overlays, ensuring stack validity.

Documentation:
- Document Docker Compose-based dev and production deployment flows, including proxy header trust configuration.
- Add a deploy checklist for the single-host Caddy setup and clarify required environment variables in production deployment docs.