### PR TITLE
fix: healthcheck auth + proxy CIDR bootstrap docs

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     command: ["python", "-m", "fieldgrade_ui", "serve"]
     healthcheck:
-      test: ["CMD", "python", "-c", "import sys, urllib.request; urllib.request.urlopen('http://127.0.0.1:8787/healthz', timeout=2).read(); sys.exit(0)"]
+      test: ["CMD", "python", "-c", "import os, sys, urllib.request; req=urllib.request.Request('http://127.0.0.1:8787/healthz', headers={'X-API-Key': os.environ.get('FG_API_TOKEN','')}); urllib.request.urlopen(req, timeout=2).read(); sys.exit(0)"]
       interval: 10s
       timeout: 3s
       retries: 10

--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -27,6 +27,8 @@ Recommended: set `FG_FORWARDED_ALLOW_IPS` to the Docker network subnet (CIDR) so
 
 Note: the network exists after the stack is brought up at least once, and the name is usually `<compose-project>_default`.
 
+Bootstrap note: for the first bring-up (before you know the CIDR), you can temporarily set `FG_FORWARDED_ALLOW_IPS=*`, bring the stack up once, inspect the CIDR, then switch to `FG_FORWARDED_ALLOW_IPS=<CIDR>` and redeploy.
+
 Optional bundle/object storage:
 
 - `FG_BUNDLE_STORE=local|s3`
@@ -47,6 +49,12 @@ Optional bundle/object storage:
 
 - Health:
   - `docker compose ps` should show `web` as `healthy`.
+
+VPS smoke (on-host):
+
+- `docker compose -f compose.yaml -f compose.production.yaml config`
+- `docker compose -f compose.yaml -f compose.production.yaml up -d --build`
+- `docker compose ps`
 
 ## 4) Live proof checks (external)
 

--- a/docs/DEPLOY_PROD_SINGLEHOST.md
+++ b/docs/DEPLOY_PROD_SINGLEHOST.md
@@ -34,6 +34,12 @@ Behind Caddy (TLS termination), configure proxy header trust explicitly:
   - If your compose project name differs, the network will be `<project>_default`. To discover it:
     - `docker network ls | grep _default`
 
+Bootstrap note (CIDR chicken-and-egg):
+
+- First boot requires *some* `FG_FORWARDED_ALLOW_IPS` value. For the initial bring-up, you can temporarily set:
+  - `FG_FORWARDED_ALLOW_IPS=*`
+- Bring the stack up once, inspect the CIDR, then set `FG_FORWARDED_ALLOW_IPS=<CIDR>` and redeploy.
+
 Optional (future-facing knobs):
 
 - `DATABASE_URL`: today must be SQLite (e.g. `sqlite:////app/fieldgrade_ui/runtime/jobs.sqlite`). Postgres is a Phase B change.


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Update deployment healthcheck to respect API authentication and improve production single-host deployment docs.

Bug Fixes:
- Ensure the Docker healthcheck calls the authenticated /healthz endpoint using the API token header.

Documentation:
- Document a bootstrap procedure for discovering the proxy network CIDR using a temporary FG_FORWARDED_ALLOW_IPS setting.
- Add explicit VPS smoke test commands to the deployment checklist for production setups.