### PR TITLE
test(fieldgrade-ui): tenant isolation kill-tests (BOLA gate)

### DIFF
--- a/fieldgrade_ui/__main__.py
+++ b/fieldgrade_ui/__main__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import ipaddress
 
-from .config import api_token, forwarded_allow_ips, proxy_headers_enabled, ui_host, ui_log_level, ui_port, ui_reload, ui_workers
+from .config import api_tokens, forwarded_allow_ips, proxy_headers_enabled, ui_host, ui_log_level, ui_port, ui_reload, ui_workers
 
 def main() -> None:
     parser = argparse.ArgumentParser(prog="python -m fieldgrade_ui")
@@ -35,7 +35,7 @@ def main() -> None:
 
     # Security: refuse to bind to a non-loopback interface unless an API token is configured.
     # This prevents path-bearing endpoints from being reachable over the network without auth.
-    tok = api_token()
+    toks = api_tokens()
 
     def _is_loopback(h: str) -> bool:
         hs = (h or "").strip()
@@ -48,10 +48,10 @@ def main() -> None:
             # Hostname or bind-all; treat as non-loopback.
             return False
 
-    if not _is_loopback(host) and not tok:
+    if not _is_loopback(host) and not toks:
         raise RuntimeError(
-            f"Refusing to bind Fieldgrade UI to host={host!r} without FG_API_TOKEN. "
-            "Set FG_API_TOKEN (and supply it as X-API-Key) or bind to 127.0.0.1."
+            f"Refusing to bind Fieldgrade UI to host={host!r} without FG_API_TOKEN/FG_API_TOKENS. "
+            "Set FG_API_TOKEN or FG_API_TOKENS (and supply it as X-API-Key) or bind to 127.0.0.1."
         )
 
     try:

--- a/fieldgrade_ui/config.py
+++ b/fieldgrade_ui/config.py
@@ -152,6 +152,23 @@ def api_token() -> str:
     return env_str("FG_API_TOKEN", "FIELDGRADE_UI_API_TOKEN", default="").strip()
 
 
+def api_tokens() -> list[str]:
+    """Return configured API tokens.
+
+    Back-compat:
+        - If FG_API_TOKENS is unset/empty, falls back to FG_API_TOKEN.
+
+    New:
+        - FG_API_TOKENS: comma-separated list of tokens (whitespace trimmed).
+    """
+    raw = env_str("FG_API_TOKENS", default="").strip()
+    if raw:
+        toks = [t.strip() for t in raw.split(",")]
+        return [t for t in toks if t]
+    t = api_token()
+    return [t] if t else []
+
+
 def database_url() -> str:
     """Return configured DB URL.
 

--- a/fieldgrade_ui/jobs.py
+++ b/fieldgrade_ui/jobs.py
@@ -14,6 +14,7 @@ class Job:
     id: int
     kind: str
     status: str
+    owner_token_hash: str
     params: Dict[str, Any]
     result: Optional[Dict[str, Any]]
     error: Optional[str]
@@ -35,6 +36,7 @@ def ensure_db(db_path: Path) -> None:
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 kind TEXT NOT NULL,
                 status TEXT NOT NULL,
+                owner_token_hash TEXT NOT NULL DEFAULT '',
                 params_json TEXT NOT NULL,
                 result_json TEXT,
                 error TEXT,
@@ -44,6 +46,12 @@ def ensure_db(db_path: Path) -> None:
             )
             """
         )
+
+        # Lightweight migration: older DBs won't have owner_token_hash.
+        cols = [r[1] for r in con.execute("PRAGMA table_info(jobs)").fetchall()]
+        if "owner_token_hash" not in cols:
+            con.execute("ALTER TABLE jobs ADD COLUMN owner_token_hash TEXT NOT NULL DEFAULT '';")
+
         con.execute(
             """
             CREATE TABLE IF NOT EXISTS job_logs (
@@ -57,6 +65,7 @@ def ensure_db(db_path: Path) -> None:
             """
         )
         con.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status, created_at);")
+        con.execute("CREATE INDEX IF NOT EXISTS idx_jobs_owner_id ON jobs(owner_token_hash, id);")
         con.execute("CREATE INDEX IF NOT EXISTS idx_job_logs_job ON job_logs(job_id, ts);")
         con.commit()
     finally:
@@ -67,13 +76,13 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     con.row_factory = sqlite3.Row
     return con
 
-def create_job(db_path: Path, kind: str, params: Dict[str, Any]) -> int:
+def create_job(db_path: Path, kind: str, params: Dict[str, Any], *, owner_token_hash: str = "") -> int:
     ensure_db(db_path)
     con = _connect(db_path)
     try:
         cur = con.execute(
-            "INSERT INTO jobs(kind, status, params_json, created_at) VALUES (?, 'queued', ?, ?)",
-            (kind, json.dumps(params, ensure_ascii=False), _now()),
+            "INSERT INTO jobs(kind, status, owner_token_hash, params_json, created_at) VALUES (?, 'queued', ?, ?, ?)",
+            (kind, owner_token_hash or "", json.dumps(params, ensure_ascii=False), _now()),
         )
         job_id = int(cur.lastrowid)
         con.execute(
@@ -84,41 +93,73 @@ def create_job(db_path: Path, kind: str, params: Dict[str, Any]) -> int:
     finally:
         con.close()
 
-def list_jobs(db_path: Path, limit: int = 50, status: Optional[str] = None) -> List[Job]:
+def list_jobs(
+    db_path: Path,
+    *,
+    owner_token_hash: Optional[str] = None,
+    limit: int = 50,
+    status: Optional[str] = None,
+) -> List[Job]:
     ensure_db(db_path)
     con = _connect(db_path)
     try:
+        where = []
+        args: list[Any] = []
+        if owner_token_hash is not None:
+            where.append("owner_token_hash=?")
+            args.append(owner_token_hash)
         if status:
-            rows = con.execute(
-                "SELECT * FROM jobs WHERE status=? ORDER BY id DESC LIMIT ?",
-                (status, limit),
-            ).fetchall()
-        else:
-            rows = con.execute(
-                "SELECT * FROM jobs ORDER BY id DESC LIMIT ?",
-                (limit,),
-            ).fetchall()
+            where.append("status=?")
+            args.append(status)
+
+        where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+        rows = con.execute(
+            f"SELECT * FROM jobs{where_sql} ORDER BY id DESC LIMIT ?",
+            tuple(args + [limit]),
+        ).fetchall()
         return [_row_to_job(r) for r in rows]
     finally:
         con.close()
 
-def get_job(db_path: Path, job_id: int) -> Optional[Job]:
+def get_job(db_path: Path, job_id: int, *, owner_token_hash: Optional[str] = None) -> Optional[Job]:
     ensure_db(db_path)
     con = _connect(db_path)
     try:
-        r = con.execute("SELECT * FROM jobs WHERE id=?", (job_id,)).fetchone()
+        if owner_token_hash is None:
+            r = con.execute("SELECT * FROM jobs WHERE id=?", (job_id,)).fetchone()
+        else:
+            r = con.execute("SELECT * FROM jobs WHERE id=? AND owner_token_hash=?", (job_id, owner_token_hash)).fetchone()
         return _row_to_job(r) if r else None
     finally:
         con.close()
 
-def get_job_logs(db_path: Path, job_id: int, limit: int = 500) -> List[Dict[str, Any]]:
+def get_job_logs(
+    db_path: Path,
+    job_id: int,
+    *,
+    owner_token_hash: Optional[str] = None,
+    limit: int = 500,
+) -> List[Dict[str, Any]]:
     ensure_db(db_path)
     con = _connect(db_path)
     try:
-        rows = con.execute(
-            "SELECT ts, level, message FROM job_logs WHERE job_id=? ORDER BY id ASC LIMIT ?",
-            (job_id, limit),
-        ).fetchall()
+        if owner_token_hash is None:
+            rows = con.execute(
+                "SELECT ts, level, message FROM job_logs WHERE job_id=? ORDER BY id ASC LIMIT ?",
+                (job_id, limit),
+            ).fetchall()
+        else:
+            rows = con.execute(
+                """
+                SELECT l.ts, l.level, l.message
+                FROM job_logs l
+                JOIN jobs j ON j.id = l.job_id
+                WHERE l.job_id=? AND j.owner_token_hash=?
+                ORDER BY l.id ASC
+                LIMIT ?
+                """,
+                (job_id, owner_token_hash, limit),
+            ).fetchall()
         return [{"ts": float(r["ts"]), "level": str(r["level"]), "message": str(r["message"])} for r in rows]
     finally:
         con.close()
@@ -134,14 +175,20 @@ def append_log(db_path: Path, job_id: int, level: str, message: str) -> None:
     finally:
         con.close()
 
-def cancel_job(db_path: Path, job_id: int) -> bool:
+def cancel_job(db_path: Path, job_id: int, *, owner_token_hash: Optional[str] = None) -> bool:
     ensure_db(db_path)
     con = _connect(db_path)
     try:
-        cur = con.execute(
-            "UPDATE jobs SET status='canceled', finished_at=? WHERE id=? AND status IN ('queued')",
-            (_now(), job_id),
-        )
+        if owner_token_hash is None:
+            cur = con.execute(
+                "UPDATE jobs SET status='canceled', finished_at=? WHERE id=? AND status IN ('queued')",
+                (_now(), job_id),
+            )
+        else:
+            cur = con.execute(
+                "UPDATE jobs SET status='canceled', finished_at=? WHERE id=? AND owner_token_hash=? AND status IN ('queued')",
+                (_now(), job_id, owner_token_hash),
+            )
         ok = cur.rowcount > 0
         if ok:
             append_log(db_path, job_id, "warn", "canceled by user")
@@ -227,6 +274,7 @@ def _row_to_job(r: Any) -> Job:
         id=int(r["id"]),
         kind=str(r["kind"]),
         status=str(r["status"]),
+        owner_token_hash=str(r["owner_token_hash"] or ""),
         params=params,
         result=result,
         error=str(r["error"]) if r["error"] else None,

--- a/fieldgrade_ui/tests/test_tenant_isolation_artifacts.py
+++ b/fieldgrade_ui/tests/test_tenant_isolation_artifacts.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _h(token: str) -> dict[str, str]:
+    return {"X-API-Key": token}
+
+
+def _owner_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("FG_API_TOKENS", "token_a,token_b")
+
+    # Isolated jobs DB per test.
+    monkeypatch.setenv("FG_JOBS_DB", str(tmp_path / "jobs.sqlite"))
+
+    # Keep termite artifacts out of the repo tree for tests.
+    monkeypatch.setenv("FG_TERMITE_ARTIFACTS_DIR", str(tmp_path / "termite_artifacts"))
+
+    # Tenant runtime root (mite_ecology DB + exports) isolated per test.
+    monkeypatch.setenv("FG_TENANTS_ROOT", str(tmp_path / "tenants"))
+
+    import fieldgrade_ui.app as app_mod
+
+    importlib.reload(app_mod)
+    return TestClient(app_mod.app)  # type: ignore[attr-defined]
+
+
+def _ensure_graph_db(db_path: Path, *, node_id: str) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(db_path))
+    try:
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS nodes (id TEXT PRIMARY KEY, type TEXT, attrs_json TEXT)"
+        )
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS edges (id INTEGER PRIMARY KEY AUTOINCREMENT, src TEXT, dst TEXT, type TEXT, attrs_json TEXT)"
+        )
+        con.execute(
+            "INSERT OR REPLACE INTO nodes(id, type, attrs_json) VALUES (?, ?, ?)",
+            (node_id, "Task", "{}"),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def test_exports_are_scoped_by_token(client: TestClient, tmp_path: Path) -> None:
+    tenants = tmp_path / "tenants"
+
+    a_owner = _owner_hash("token_a")
+    b_owner = _owner_hash("token_b")
+
+    a_exports = tenants / a_owner / "exports"
+    b_exports = tenants / b_owner / "exports"
+    a_exports.mkdir(parents=True, exist_ok=True)
+    b_exports.mkdir(parents=True, exist_ok=True)
+
+    (a_exports / "a.json").write_text("{}", encoding="utf-8")
+    (b_exports / "b.json").write_text("{}", encoding="utf-8")
+
+    r = client.get("/api/exports", headers=_h("token_a"))
+    assert r.status_code == 200
+    exports = r.json()["exports"]
+    assert any(p.endswith("a.json") for p in exports)
+    assert not any(p.endswith("b.json") for p in exports)
+
+    r = client.get("/api/exports", headers=_h("token_b"))
+    assert r.status_code == 200
+    exports = r.json()["exports"]
+    assert any(p.endswith("b.json") for p in exports)
+    assert not any(p.endswith("a.json") for p in exports)
+
+
+def test_graph_endpoints_use_token_scoped_db(client: TestClient, tmp_path: Path) -> None:
+    tenants = tmp_path / "tenants"
+
+    a_owner = _owner_hash("token_a")
+    b_owner = _owner_hash("token_b")
+
+    a_db = tenants / a_owner / "runtime" / "mite_ecology.sqlite"
+    b_db = tenants / b_owner / "runtime" / "mite_ecology.sqlite"
+
+    _ensure_graph_db(a_db, node_id="a1")
+    _ensure_graph_db(b_db, node_id="b1")
+
+    r = client.get("/api/graph/nodes", headers=_h("token_a"))
+    assert r.status_code == 200
+    ids = [n["id"] for n in r.json()["nodes"]]
+    assert "a1" in ids
+    assert "b1" not in ids
+
+    r = client.get("/api/graph/nodes", headers=_h("token_b"))
+    assert r.status_code == 200
+    ids = [n["id"] for n in r.json()["nodes"]]
+    assert "b1" in ids
+    assert "a1" not in ids
+
+    # Neighborhood lookup should not cross tenants.
+    r = client.get("/api/graph/neighborhood", params={"node_id": "a1"}, headers=_h("token_b"))
+    assert r.status_code == 404
+
+
+def test_bundles_are_scoped_by_token_via_job_results(client: TestClient, tmp_path: Path) -> None:
+    # Seed a fake bundle file under the test artifacts root, and register it via a succeeded job.
+    bundles_dir = tmp_path / "termite_artifacts" / "bundles_out"
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = bundles_dir / "demo.zip"
+    bundle_path.write_bytes(b"PK\x03\x04")  # minimal zip signature prefix
+
+    # Register bundle for token_a via jobs DB.
+    from fieldgrade_ui.jobs import create_job, succeed_job
+
+    owner = _owner_hash("token_a")
+    job_id = create_job(
+        tmp_path / "jobs.sqlite",
+        "pipeline",
+        {"label": "x"},
+        owner_token_hash=owner,
+    )
+    succeed_job(tmp_path / "jobs.sqlite", job_id, {"bundle_path": str(bundle_path)})
+
+    r = client.get("/api/bundles", headers=_h("token_a"))
+    assert r.status_code == 200
+    bundles = r.json()["bundles"]
+    assert any(p.endswith("demo.zip") for p in bundles)
+
+    r = client.get("/api/bundles", headers=_h("token_b"))
+    assert r.status_code == 200
+    bundles = r.json()["bundles"]
+    assert not any(p.endswith("demo.zip") for p in bundles)

--- a/fieldgrade_ui/tests/test_tenant_isolation_jobs.py
+++ b/fieldgrade_ui/tests/test_tenant_isolation_jobs.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client_and_upload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Two distinct principals (tenants) for BOLA-style isolation tests.
+    monkeypatch.setenv("FG_API_TOKENS", "token_a,token_b")
+
+    # Isolated DB per test.
+    monkeypatch.setenv("FG_JOBS_DB", str(tmp_path / "jobs.sqlite"))
+
+    # Allow the test upload path via sandbox extra roots.
+    uploads = tmp_path / "uploads"
+    uploads.mkdir(parents=True, exist_ok=True)
+    upload_path = uploads / "demo.txt"
+    upload_path.write_text("hello", encoding="utf-8")
+    monkeypatch.setenv("FG_API_EXTRA_ROOTS", str(uploads))
+
+    import fieldgrade_ui.app as app_mod
+
+    # app.py reads env at import time; ensure a clean reload after env is set.
+    importlib.reload(app_mod)
+
+    return TestClient(app_mod.app), upload_path
+
+
+def _h(token: str) -> dict[str, str]:
+    return {"X-API-Key": token}
+
+
+def test_jobs_are_scoped_by_api_token(client_and_upload):
+    client, upload_path = client_and_upload
+
+    # Tenant A creates a job.
+    r = client.post(
+        "/api/jobs/pipeline",
+        headers=_h("token_a"),
+        json={"upload_path": str(upload_path), "label": "a"},
+    )
+    assert r.status_code == 200, r.text
+    job_id = int(r.json()["job_id"])
+
+    # Tenant A can see it.
+    r = client.get(f"/api/jobs/{job_id}", headers=_h("token_a"))
+    assert r.status_code == 200, r.text
+
+    # Tenant B cannot see it (404 to avoid existence oracle).
+    r = client.get(f"/api/jobs/{job_id}", headers=_h("token_b"))
+    assert r.status_code == 404, r.text
+
+    # Tenant B cannot access logs.
+    r = client.get(f"/api/jobs/{job_id}/logs", headers=_h("token_b"))
+    assert r.status_code == 404, r.text
+
+    # Tenant B cannot cancel it.
+    r = client.post(f"/api/jobs/{job_id}/cancel", headers=_h("token_b"))
+    assert r.status_code == 404, r.text
+
+    # Lists are scoped too.
+    r = client.get("/api/jobs", headers=_h("token_b"))
+    assert r.status_code == 200, r.text
+    assert r.json()["jobs"] == []
+
+
+def test_invalid_token_is_rejected(client_and_upload):
+    client, upload_path = client_and_upload
+
+    r = client.post(
+        "/api/jobs/pipeline",
+        headers=_h("wrong"),
+        json={"upload_path": str(upload_path), "label": "x"},
+    )
+    assert r.status_code == 401

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,5 @@ pythonpath =
 testpaths =
     termite_fieldpack/tests
     mite_ecology/tests
+    fieldgrade_ui/tests
 addopts = -q


### PR DESCRIPTION
- Add FG_API_TOKENS support (multi-token auth) with FG_API_TOKEN back-compat

- Scope jobs to caller via owner_token_hash (including logs/cancel)

- Scope bundles/exports/graph DB per token in multi-tenant mode

- Add kill-tests covering cross-token access for jobs + artifacts

- Include fieldgrade_ui/tests in default pytest discovery

## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Introduce multi-token API authentication and per-token tenant isolation for jobs, artifacts, and graph data.

New Features:
- Support multiple API tokens via FG_API_TOKENS with backward compatibility for FG_API_TOKEN.
- Expose tenant-related runtime state (tenants root and multi-tenant flag) via the /api/state endpoint.

Enhancements:
- Scope jobs, logs, cancellations, and metrics to the calling token using an owner hash in the jobs database.
- Isolate bundles, exports, ecology configuration, and graph database access per API token in multi-tenant mode, including termite and ecology pipeline operations.
- Enforce visibility checks on bundles before verify, replay, and ecology operations to prevent cross-tenant access.
- Update CLI startup checks so non-loopback binding requires at least one configured API token and allow multi-tenant artifacts root override via environment variables.

Tests:
- Add pytest coverage for tenant isolation of jobs, bundles, exports, and graph endpoints, and include fieldgrade_ui/tests in default test discovery.