### PR TITLE
ci: add manual VPS deploy workflow

### DIFF
--- a/.github/workflows/deploy_vps.yml
+++ b/.github/workflows/deploy_vps.yml
@@ -1,0 +1,98 @@
+name: deploy_vps
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy (branch, tag, or SHA)"
+        required: true
+        default: "main"
+      readyz_url:
+        description: "External URL to /readyz (e.g. https://fieldgrade.example.com/readyz)"
+        required: true
+      compose_files:
+        description: "Compose files (space-separated), relative to deploy path"
+        required: true
+        default: "compose.yaml compose.production.yaml"
+      deploy_path:
+        description: "Absolute path to fg_next on the VPS"
+        required: true
+        default: "/opt/fieldgrade/fg_next"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-vps
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout (for metadata only)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Start ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+
+      - name: Add known_hosts
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          if [ -n "${{ secrets.VPS_SSH_KNOWN_HOSTS }}" ]; then
+            printf '%s\n' "${{ secrets.VPS_SSH_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+          else
+            echo "Missing secret VPS_SSH_KNOWN_HOSTS (recommended)." >&2
+            echo "Generate with: ssh-keyscan -H <host>" >&2
+            exit 1
+          fi
+
+      - name: Deploy via SSH
+        shell: bash
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_PORT: ${{ secrets.VPS_PORT }}
+          REF: ${{ inputs.ref }}
+          DEPLOY_PATH: ${{ inputs.deploy_path }}
+          COMPOSE_FILES: ${{ inputs.compose_files }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${VPS_PORT:-}" ]; then
+            VPS_PORT="22"
+          fi
+
+          compose_args=""
+          for f in ${COMPOSE_FILES}; do
+            compose_args="${compose_args} -f ${f}"
+          done
+
+          ssh -p "${VPS_PORT}" "${VPS_USER}@${VPS_HOST}" bash -lc "
+            set -euo pipefail
+            cd '${DEPLOY_PATH}'
+
+            git fetch --all --prune
+            git checkout '${REF}'
+            git pull --ff-only origin '${REF}' || true
+
+            docker compose ${compose_args} config >/dev/null
+            docker compose ${compose_args} up -d --build
+            docker compose ${compose_args} ps
+          "
+
+      - name: Verify /readyz
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="${{ inputs.readyz_url }}"
+          curl -fsS "$url" | head -c 200

--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -75,3 +75,21 @@ If scheme/redirect behavior is correct (no `http://` confusion), proxy headers a
 - Revert to a known-good commit:
   - `git checkout <sha>`
   - `docker compose -f compose.yaml -f compose.production.yaml up -d --build`
+
+## Optional: GitHub Actions deploy (workflow_dispatch)
+
+This repo includes a manual deploy workflow: `.github/workflows/deploy_vps.yml`.
+
+Required GitHub secrets:
+
+- `VPS_HOST`
+- `VPS_USER`
+- `VPS_SSH_PRIVATE_KEY`
+- `VPS_SSH_KNOWN_HOSTS` (recommended; output of `ssh-keyscan -H <host>`)
+- `VPS_PORT` (optional; defaults to 22)
+
+Run it from the GitHub UI and provide:
+
+- `deploy_path` (path to `fg_next/` on the VPS)
+- `compose_files` (defaults to `compose.yaml compose.production.yaml`)
+- `readyz_url` (external URL to `/readyz`)


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Add a manually triggered GitHub Actions workflow to deploy the application to a VPS and document how to use it, including required secrets and parameters.

CI:
- Introduce a workflow_dispatch-based deploy_vps GitHub Actions workflow that SSHes into a VPS, updates the git ref, runs Docker Compose with configurable files, and verifies the /readyz endpoint.

Documentation:
- Document the optional manual VPS deployment workflow, including required GitHub secrets and input parameters such as deploy_path, compose_files, and readyz_url.