### PR TITLE
test: treat deprecation warnings as errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ python -m pytest -q
 
 After bootstrapping, you can run the CLIs (`termite`, `mite-ecology`, `fieldgrade-ui`) or follow the fast-start flows below.
 
+### Warnings policy
+
+Pytest is configured to treat `DeprecationWarning` and `PendingDeprecationWarning` as errors (CI gate).
+If a new dependency or change introduces these warnings, fix or isolate it before merging.
+
 ## 1) `termite_fieldpack/` (Termux/field/offline)
 A fieldable toolchain that can:
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,7 @@ testpaths =
     mite_ecology/tests
     fieldgrade_ui/tests
 addopts = -q
+
+filterwarnings =
+    error::DeprecationWarning
+    error::PendingDeprecationWarning


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Treat deprecation warnings as test failures and document the project’s warnings policy.

Documentation:
- Document the pytest deprecation warning policy and expectations for handling new warnings in the README.

Tests:
- Configure pytest to fail on DeprecationWarning and PendingDeprecationWarning during test runs.