### PR TITLE
ops: add Docker volume backup script + systemd timer

### DIFF
--- a/docs/DEPLOY_BACKUP_RESTORE.md
+++ b/docs/DEPLOY_BACKUP_RESTORE.md
@@ -1,0 +1,116 @@
+# Backups + restore drill (single-host v0)
+
+Single-host v0 keeps state in Docker volumes:
+
+- termite runtime + artifacts
+- mite_ecology runtime + artifacts
+- fieldgrade_ui runtime
+- Caddy cert/state
+
+This guide provides a minimal, repeatable backup + restore flow.
+
+## Backup (recommended nightly)
+
+This repo includes a VPS helper script:
+
+- `scripts/vps_backup_volumes.sh`
+
+It archives **all** Docker volumes labeled with:
+
+- `com.docker.compose.project=<project>`
+
+### One-time setup
+
+1) Choose a predictable compose project name on the VPS.
+
+Recommended: export `COMPOSE_PROJECT_NAME=fg_next` in your shell or set it in your systemd env file (below).
+
+2) Create a backup destination:
+
+- `sudo mkdir -p /var/backups/fieldgrade`
+- `sudo chmod 700 /var/backups/fieldgrade`
+
+### Manual backup run
+
+From the `fg_next/` directory on the VPS:
+
+- Hot backup (no downtime; may be inconsistent for SQLite under write load):
+  - `./scripts/vps_backup_volumes.sh --backup-dir /var/backups/fieldgrade --keep-days 14`
+
+- Cold backup (recommended; stops and restarts the stack):
+  - `./scripts/vps_backup_volumes.sh --backup-dir /var/backups/fieldgrade --keep-days 14 --compose-files "compose.yaml compose.production.yaml" --stop-stack --restart-stack`
+
+Each run produces a directory like:
+
+- `/var/backups/fieldgrade/volumes_<project>_<timestamp>/`
+
+Including:
+
+- one `*.tar.gz` per volume
+- `VOLUMES.txt`
+- `SHA256SUMS.txt`
+
+## systemd timer (nightly)
+
+Unit files are provided in:
+
+- `scripts/systemd/fieldgrade-volumes-backup.service`
+- `scripts/systemd/fieldgrade-volumes-backup.timer`
+
+### Install
+
+On the VPS:
+
+- `sudo install -D -m 0644 scripts/systemd/fieldgrade-volumes-backup.service /etc/systemd/system/fieldgrade-volumes-backup.service`
+- `sudo install -D -m 0644 scripts/systemd/fieldgrade-volumes-backup.timer /etc/systemd/system/fieldgrade-volumes-backup.timer`
+
+Optional env overrides (recommended):
+
+- `sudo install -D -m 0600 /dev/null /etc/fieldgrade/backup.env`
+- Edit `/etc/fieldgrade/backup.env`:
+  - `COMPOSE_PROJECT_NAME=fg_next`
+  - `BACKUP_DIR=/var/backups/fieldgrade`
+  - `KEEP_DAYS=14`
+
+Enable timer:
+
+- `sudo systemctl daemon-reload`
+- `sudo systemctl enable --now fieldgrade-volumes-backup.timer`
+
+Check status/logs:
+
+- `systemctl list-timers --all | grep fieldgrade`
+- `sudo journalctl -u fieldgrade-volumes-backup.service -n 200 --no-pager`
+
+## Restore drill (practice)
+
+Do this on a staging VPS or during a maintenance window.
+
+1) Pick a backup directory (example):
+
+- `/var/backups/fieldgrade/volumes_fg_next_20251231T033000Z/`
+
+2) Stop the stack:
+
+- `docker compose -p fg_next -f compose.yaml -f compose.production.yaml down`
+
+3) Restore volumes:
+
+For each volume tarball in the backup directory:
+
+- Ensure the volume exists:
+  - `docker volume create <volume_name>`
+- Restore into it:
+  - `docker run --rm -v <volume_name>:/v -v /var/backups/fieldgrade/volumes_fg_next_...:/in alpine:3.20 sh -lc "cd /v && rm -rf ./* && tar -xzf /in/<volume_name>.tar.gz"`
+
+4) Bring stack up:
+
+- `docker compose -p fg_next -f compose.yaml -f compose.production.yaml up -d --build`
+
+5) Verify externally:
+
+- `https://$FIELDGRADE_DOMAIN/readyz`
+
+Notes:
+- If you change `COMPOSE_PROJECT_NAME`, your volume names will change.
+- For Phase 3 (managed Postgres), switch backups to Postgres-native snapshots/PITR and treat volumes as cache/artifacts.

--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -70,6 +70,10 @@ If scheme/redirect behavior is correct (no `http://` confusion), proxy headers a
 - Backups: all state is in Docker named volumes (including the SQLite jobs DB).
 - Restarts: `compose.production.yaml` sets `restart: always`.
 
+Backup/restore guide:
+
+- See `docs/DEPLOY_BACKUP_RESTORE.md`.
+
 ## 6) Rollback
 
 - Revert to a known-good commit:

--- a/scripts/systemd/fieldgrade-volumes-backup.service
+++ b/scripts/systemd/fieldgrade-volumes-backup.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Fieldgrade: backup Docker volumes (Compose project)
+Wants=network-online.target
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+# Adjust to where you have the repo checked out on the VPS
+WorkingDirectory=/opt/fieldgrade/fg_next
+
+# Optional: put overrides here (COMPOSE_PROJECT_NAME, BACKUP_DIR, etc.)
+# Example:
+#   COMPOSE_PROJECT_NAME=fg_next
+#   BACKUP_DIR=/var/backups/fieldgrade
+EnvironmentFile=-/etc/fieldgrade/backup.env
+
+# Recommended "cold" backup: stop stack, back up volumes, restart stack.
+ExecStart=/opt/fieldgrade/fg_next/scripts/vps_backup_volumes.sh \
+  --backup-dir ${BACKUP_DIR:-/var/backups/fieldgrade} \
+  --keep-days ${KEEP_DAYS:-14} \
+  --compose-files "compose.yaml compose.production.yaml" \
+  --stop-stack --restart-stack
+
+# Log output to journald
+StandardOutput=journal
+StandardError=journal

--- a/scripts/systemd/fieldgrade-volumes-backup.timer
+++ b/scripts/systemd/fieldgrade-volumes-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Fieldgrade: nightly Docker volume backup
+
+[Timer]
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+RandomizedDelaySec=10m
+
+[Install]
+WantedBy=timers.target

--- a/scripts/vps_backup_volumes.sh
+++ b/scripts/vps_backup_volumes.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  vps_backup_volumes.sh [options]
+
+Back up all Docker volumes labeled with com.docker.compose.project=<project>.
+This captures Fieldgrade state (runtime DBs, artifacts, and Caddy state) in
+one timestamped directory.
+
+Options:
+  --project NAME             Compose project name (default: $COMPOSE_PROJECT_NAME or basename of CWD)
+  --backup-dir PATH          Where backups are written (default: /var/backups/fieldgrade)
+  --keep-days N              Delete backup directories older than N days (default: 14)
+  --compose-files "a b c"     Space-separated compose files for stop/restart actions
+  --stop-stack               Stop the compose stack before backing up (safer for SQLite)
+  --restart-stack            Bring the compose stack back up after backup (implies --compose-files)
+  -h, --help                 Show help
+
+Example (recommended nightly "cold" backup):
+  cd /opt/fieldgrade/fg_next
+  COMPOSE_PROJECT_NAME=fg_next \
+    ./scripts/vps_backup_volumes.sh \
+      --backup-dir /var/backups/fieldgrade \
+      --compose-files "compose.yaml compose.production.yaml" \
+      --stop-stack --restart-stack
+EOF
+}
+
+project="${COMPOSE_PROJECT_NAME:-$(basename "$(pwd)")}" 
+backup_dir="/var/backups/fieldgrade"
+keep_days="14"
+compose_files=""
+stop_stack="0"
+restart_stack="0"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project)
+      project="$2"; shift 2 ;;
+    --backup-dir)
+      backup_dir="$2"; shift 2 ;;
+    --keep-days)
+      keep_days="$2"; shift 2 ;;
+    --compose-files)
+      compose_files="$2"; shift 2 ;;
+    --stop-stack)
+      stop_stack="1"; shift 1 ;;
+    --restart-stack)
+      restart_stack="1"; shift 1 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$restart_stack" = "1" ] && [ -z "${compose_files}" ]; then
+  echo "--restart-stack requires --compose-files" >&2
+  exit 2
+fi
+
+mkdir -p "$backup_dir"
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${backup_dir%/}/volumes_${project}_${ts}"
+mkdir -p "$out_dir"
+
+compose_args=()
+if [ -n "${compose_files}" ]; then
+  # shellcheck disable=SC2206
+  files=( ${compose_files} )
+  for f in "${files[@]}"; do
+    compose_args+=( -f "$f" )
+  done
+fi
+
+if [ "$stop_stack" = "1" ]; then
+  if [ ${#compose_args[@]} -eq 0 ]; then
+    echo "--stop-stack requires --compose-files" >&2
+    exit 2
+  fi
+  echo "[backup] stopping compose stack (project=${project})"
+  docker compose -p "$project" "${compose_args[@]}" stop
+fi
+
+echo "[backup] enumerating volumes for compose project: ${project}"
+mapfile -t volumes < <(docker volume ls -q --filter "label=com.docker.compose.project=${project}" | sort)
+
+if [ "${#volumes[@]}" -eq 0 ]; then
+  echo "[backup] no volumes found with label com.docker.compose.project=${project}" >&2
+  echo "[backup] tip: set --project to your compose project name" >&2
+  exit 1
+fi
+
+echo "[backup] writing to: ${out_dir}"
+printf '%s\n' "${volumes[@]}" > "${out_dir}/VOLUMES.txt"
+
+for v in "${volumes[@]}"; do
+  out_file="${out_dir}/${v}.tar.gz"
+  echo "[backup] volume: ${v} -> ${out_file}"
+  docker run --rm \
+    -v "${v}:/v:ro" \
+    -v "${out_dir}:/out" \
+    alpine:3.20 \
+    sh -lc "cd /v && tar -czf '/out/$(basename "${out_file}")' ."
+done
+
+# Basic integrity check
+( cd "$out_dir" && sha256sum *.tar.gz > SHA256SUMS.txt )
+
+# Cleanup old backups
+if [ -n "${keep_days}" ] && [ "$keep_days" -ge 1 ] 2>/dev/null; then
+  echo "[backup] pruning backups older than ${keep_days} days in ${backup_dir}"
+  find "$backup_dir" -maxdepth 1 -type d -name "volumes_${project}_*" -mtime "+${keep_days}" -print0 | xargs -0r rm -rf
+fi
+
+if [ "$restart_stack" = "1" ]; then
+  echo "[backup] restarting compose stack (project=${project})"
+  docker compose -p "$project" "${compose_args[@]}" up -d
+fi
+
+echo "[backup] done"


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Add a Docker volume backup utility with documentation and systemd integration for scheduled backups and restores.

New Features:
- Introduce a VPS helper script to back up Docker volumes for a specified compose project, with optional stack stop/restart and automatic pruning of old backups.

Deployment:
- Add systemd service and timer unit files to run the Docker volume backup script on a scheduled basis.

Documentation:
- Add a deployment backup and restore guide documenting nightly backups, systemd timer setup, and restore drills for single-host deployments.
- Link the deployment checklist to the new backup and restore documentation for easier discovery.