### PR TITLE
registry: add local catalogs + schema stubs

### DIFF
--- a/mite_ecology/registry/components_v1.yaml
+++ b/mite_ecology/registry/components_v1.yaml
@@ -1,0 +1,3 @@
+type: registry_components/1.0
+version: "1.0"
+components: []

--- a/mite_ecology/registry/remotes_v1.yaml
+++ b/mite_ecology/registry/remotes_v1.yaml
@@ -1,0 +1,3 @@
+type: registry_remotes/1.0
+version: "1.0"
+remotes: []

--- a/mite_ecology/registry/variants_v1.yaml
+++ b/mite_ecology/registry/variants_v1.yaml
@@ -1,0 +1,3 @@
+type: registry_variants/1.0
+version: "1.0"
+variants: []

--- a/schemas/ldna_registry.yaml
+++ b/schemas/ldna_registry.yaml
@@ -10,6 +10,12 @@ schemas:
   description: Motif spec (GNN/GAT/etc) payload
 - uri: ldna://json/neuroarch_dsl@1.0.0
   description: Neuroarch DSL fragment
+- uri: ldna://yaml/registry_components@1.0.0
+  description: Registry catalog (components)
+- uri: ldna://yaml/registry_variants@1.0.0
+  description: Registry catalog (variants)
+- uri: ldna://yaml/registry_remotes@1.0.0
+  description: Registry remotes configuration
 compat:
   rule: major_version_compat
   notes: Consumers must accept same major; producers may emit higher minor/patch.

--- a/schemas/registry_components_v1.json
+++ b/schemas/registry_components_v1.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://mite-ecology.local/schemas/registry_components_v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "type": { "type": "string", "const": "registry_components/1.0" },
+    "version": { "type": "string", "minLength": 1 },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "component_id": { "type": "string", "minLength": 1 },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "schemas": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "inputs": { "type": "array", "items": { "type": "string" } },
+              "outputs": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        },
+        "required": ["component_id"]
+      }
+    }
+  },
+  "required": ["type", "version", "components"]
+}

--- a/schemas/registry_remotes_v1.json
+++ b/schemas/registry_remotes_v1.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://mite-ecology.local/schemas/registry_remotes_v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "type": { "type": "string", "const": "registry_remotes/1.0" },
+    "version": { "type": "string", "minLength": 1 },
+    "remotes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "remote_id": { "type": "string", "minLength": 1 },
+          "tuf_base": { "type": "string", "minLength": 1 },
+          "enabled": { "type": "boolean" },
+          "cache": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "ttl_seconds": { "type": "integer", "minimum": 0 },
+              "cache_dir": { "type": "string" }
+            }
+          },
+          "trust": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "tuf_root_pubkeys": { "type": "array", "items": { "type": "object" } }
+            }
+          }
+        },
+        "required": ["remote_id", "tuf_base"]
+      }
+    }
+  },
+  "required": ["type", "version", "remotes"]
+}

--- a/schemas/registry_variants_v1.json
+++ b/schemas/registry_variants_v1.json
@@ -1,0 +1,46 @@
+{
+  "$id": "https://mite-ecology.local/schemas/registry_variants_v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "type": { "type": "string", "const": "registry_variants/1.0" },
+    "version": { "type": "string", "minLength": 1 },
+    "variants": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "variant_id": { "type": "string", "minLength": 1 },
+          "title": { "type": "string" },
+          "lineage_tag": { "type": "string" },
+          "description": { "type": "string" },
+          "compat": { "type": "array", "items": { "type": "string" } },
+          "releases": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "release_id": { "type": "string", "minLength": 1 },
+                "created_utc": { "type": "string" },
+                "bundle": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "sha256": { "type": "string", "minLength": 1 },
+                    "bytes": { "type": "integer", "minimum": 0 }
+                  }
+                }
+              },
+              "required": ["release_id"]
+            }
+          }
+        },
+        "required": ["variant_id"]
+      }
+    }
+  },
+  "required": ["type", "version", "variants"]
+}


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Introduce schema support and local stubs for registry components, variants, and remotes catalogs.

New Features:
- Register new YAML schemas for registry components, variants, and remotes in the LDNA registry schema index.
- Add initial local catalog stub files for registry components, variants, and remotes.

Enhancements:
- Add versioned JSON schema placeholders for registry components, variants, and remotes definitions.