### PR TITLE
Epic D: deterministic release artifacts

### DIFF
--- a/fieldgrade_ui/tests/test_releases_endpoints.py
+++ b/fieldgrade_ui/tests/test_releases_endpoints.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _h(token: str) -> dict[str, str]:
+    return {"X-API-Key": token}
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("FG_API_TOKENS", "token_a,token_b")
+
+    # Isolated jobs DB per test.
+    monkeypatch.setenv("FG_JOBS_DB", str(tmp_path / "jobs.sqlite"))
+
+    # Keep termite artifacts out of the repo tree for tests.
+    monkeypatch.setenv("FG_TERMITE_ARTIFACTS_DIR", str(tmp_path / "termite_artifacts"))
+
+    # Tenant runtime root isolated per test.
+    monkeypatch.setenv("FG_TENANTS_ROOT", str(tmp_path / "tenants"))
+
+    import fieldgrade_ui.app as app_mod
+
+    importlib.reload(app_mod)
+    return TestClient(app_mod.app)  # type: ignore[attr-defined]
+
+
+def test_release_build_and_list(client: TestClient) -> None:
+    r = client.post("/api/releases/build", headers=_h("token_a"))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["release_id"]
+    assert body["zip_path"].endswith(body["release_id"] + ".zip")
+    assert body["zip_sha256"]
+
+    r = client.get("/api/releases", headers=_h("token_a"))
+    assert r.status_code == 200, r.text
+    items = r.json()["releases"]
+    assert any(x["release_id"] == body["release_id"] for x in items)

--- a/mite_ecology/mite_ecology/release.py
+++ b/mite_ecology/mite_ecology/release.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import time
+import zipfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .hashutil import canonical_json, sha256_hex, sha256_str
+from .registry import RegistryLoadResult, load_components_registry, load_remotes_registry, load_variants_registry
+
+
+@dataclass(frozen=True)
+class ReleaseBuildResult:
+    release_id: str
+    created_utc: str
+    manifest_sha256: str
+    out_dir: str
+    manifest_path: str
+    zip_path: str
+    registries: Dict[str, Dict[str, Any]]
+
+
+def _utc_iso(ts: Optional[float] = None) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts or time.time()))
+
+
+def _deterministic_zip_write(zip_path: Path, files: Dict[str, bytes]) -> None:
+    """Write a deterministic zip (stable ordering + fixed timestamps)."""
+
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Fixed earliest DOS timestamp to keep bytes stable.
+    fixed_dt = (1980, 1, 1, 0, 0, 0)
+
+    with zipfile.ZipFile(zip_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as zf:
+        for name in sorted(files.keys()):
+            data = files[name]
+            zi = zipfile.ZipInfo(filename=name, date_time=fixed_dt)
+            zi.compress_type = zipfile.ZIP_DEFLATED
+            # Force consistent file mode bits.
+            zi.external_attr = 0o644 << 16
+            zf.writestr(zi, data)
+
+
+def _registry_record(r: RegistryLoadResult) -> Dict[str, Any]:
+    return {
+        "path": r.path,
+        "canonical_sha256": r.canonical_sha256,
+    }
+
+
+def build_release(
+    *,
+    out_dir: str | Path,
+    components_path: str | Path | None = None,
+    variants_path: str | Path | None = None,
+    remotes_path: str | Path | None = None,
+) -> ReleaseBuildResult:
+    """Build a deterministic release artifact.
+
+    Produces:
+      - {out_dir}/{release_id}/manifest.json
+      - {out_dir}/{release_id}/registries/{components,variants,remotes}.json
+      - {out_dir}/{release_id}.zip (deterministic zip)
+
+    The release_id is derived from the sha256 of the canonical manifest JSON.
+    """
+
+    out_root = Path(out_dir)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    comp = load_components_registry(components_path)
+    var = load_variants_registry(variants_path)
+    rem = load_remotes_registry(remotes_path)
+
+    created = _utc_iso()
+
+    manifest_obj: Dict[str, Any] = {
+        "type": "fieldgrade_release/1.0",
+        "version": "1.0",
+        "created_utc": created,
+        "registries": {
+            "components": _registry_record(comp),
+            "variants": _registry_record(var),
+            "remotes": _registry_record(rem),
+        },
+    }
+
+    manifest_canon = canonical_json(manifest_obj)
+    manifest_sha = sha256_str(manifest_canon)
+    release_id = manifest_sha[:16]
+
+    # Write directory layout
+    rel_dir = out_root / release_id
+    reg_dir = rel_dir / "registries"
+    reg_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = rel_dir / "manifest.json"
+    manifest_path.write_text(manifest_canon, encoding="utf-8")
+
+    (reg_dir / "components.json").write_text(comp.canonical_json, encoding="utf-8")
+    (reg_dir / "variants.json").write_text(var.canonical_json, encoding="utf-8")
+    (reg_dir / "remotes.json").write_text(rem.canonical_json, encoding="utf-8")
+
+    # Deterministic zip content
+    zip_path = out_root / f"{release_id}.zip"
+    zip_files = {
+        "manifest.json": manifest_canon.encode("utf-8"),
+        "registries/components.json": comp.canonical_json.encode("utf-8"),
+        "registries/variants.json": var.canonical_json.encode("utf-8"),
+        "registries/remotes.json": rem.canonical_json.encode("utf-8"),
+    }
+    _deterministic_zip_write(zip_path, zip_files)
+
+    return ReleaseBuildResult(
+        release_id=release_id,
+        created_utc=created,
+        manifest_sha256=manifest_sha,
+        out_dir=str(out_root),
+        manifest_path=str(manifest_path),
+        zip_path=str(zip_path),
+        registries={
+            "components": _registry_record(comp),
+            "variants": _registry_record(var),
+            "remotes": _registry_record(rem),
+        },
+    )
+
+
+def load_release_manifest(path: str | Path) -> Dict[str, Any]:
+    p = Path(path)
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def release_zip_sha256(path: str | Path) -> str:
+    p = Path(path)
+    return sha256_hex(p.read_bytes())

--- a/mite_ecology/tests/test_release_build_deterministic.py
+++ b/mite_ecology/tests/test_release_build_deterministic.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from mite_ecology.release import build_release, release_zip_sha256
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_release_build_is_deterministic(tmp_path: Path) -> None:
+    # Minimal valid registries that satisfy the JSON Schemas.
+    comps = tmp_path / "components.yaml"
+    vars_ = tmp_path / "variants.yaml"
+    rems = tmp_path / "remotes.yaml"
+
+    _write(
+        comps,
+        "\n".join(
+            [
+                "type: registry_components/1.0",
+                "version: '1.0'",
+                "components:",
+                "  - component_id: demo_component",
+            ]
+        )
+        + "\n",
+    )
+
+    _write(
+        vars_,
+        "\n".join(
+            [
+                "type: registry_variants/1.0",
+                "version: '1.0'",
+                "variants:",
+                "  - variant_id: demo_variant",
+            ]
+        )
+        + "\n",
+    )
+
+    _write(
+        rems,
+        "\n".join(
+            [
+                "type: registry_remotes/1.0",
+                "version: '1.0'",
+                "remotes: []",
+            ]
+        )
+        + "\n",
+    )
+
+    out1 = tmp_path / "out1"
+    out2 = tmp_path / "out2"
+
+    r1 = build_release(
+        out_dir=out1,
+        components_path=comps,
+        variants_path=vars_,
+        remotes_path=rems,
+    )
+    r2 = build_release(
+        out_dir=out2,
+        components_path=comps,
+        variants_path=vars_,
+        remotes_path=rems,
+    )
+
+    assert r1.release_id == r2.release_id
+    assert r1.manifest_sha256 == r2.manifest_sha256
+
+    # Zip bytes should also be stable.
+    assert release_zip_sha256(r1.zip_path) == release_zip_sha256(r2.zip_path)


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Introduce deterministic release artifact building and expose it via CLI and HTTP APIs.

New Features:
- Add a deterministic release build module that produces manifest-identified ZIP artifacts from registries.
- Expose a CLI command to build releases with configurable registry paths and output directory.
- Add HTTP endpoints to build release artifacts and list existing releases, with tenant-aware storage paths.

Tests:
- Add tests to verify release builds are deterministic across runs given the same registries.
- Add API tests to verify release build and listing endpoints behave as expected.