### PR TITLE
Epic E: release DSSE attestations + verify

### DIFF
--- a/mite_ecology/mite_ecology/release.py
+++ b/mite_ecology/mite_ecology/release.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import time
 import zipfile
+import hashlib
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -22,8 +23,54 @@ class ReleaseBuildResult:
     registries: Dict[str, Dict[str, Any]]
 
 
+DETERMINISTIC_CREATED_UTC = "1970-01-01T00:00:00Z"
+
+
 def _utc_iso(ts: Optional[float] = None) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts or time.time()))
+
+
+def _sha256_bytes(data: bytes) -> str:
+    h = hashlib.sha256()
+    h.update(data)
+    return h.hexdigest()
+
+
+def _build_release_cyclonedx_bom(*, release_id: str, manifest_sha256: str, registries: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """Build a minimal, deterministic CycloneDX BOM describing the release payload.
+
+    This intentionally avoids environment-derived data (installed packages, timestamps).
+    """
+    components = []
+    for k in sorted(registries.keys()):
+        r = registries[k]
+        components.append(
+            {
+                "type": "file",
+                "name": f"registries/{k}.json",
+                "hashes": [{"alg": "SHA-256", "content": str(r.get("canonical_sha256") or "")}],
+            }
+        )
+
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "version": 1,
+        "metadata": {
+            "tools": [
+                {
+                    "vendor": "Fieldgrade",
+                    "name": "mite_ecology",
+                    "version": "0.1",
+                }
+            ],
+            "properties": [
+                {"name": "fieldgrade.release_id", "value": str(release_id)},
+                {"name": "fieldgrade.manifest_sha256", "value": str(manifest_sha256)},
+            ],
+        },
+        "components": components,
+    }
 
 
 def _deterministic_zip_write(zip_path: Path, files: Dict[str, bytes]) -> None:
@@ -57,6 +104,11 @@ def build_release(
     components_path: str | Path | None = None,
     variants_path: str | Path | None = None,
     remotes_path: str | Path | None = None,
+    signing_public_key_path: str | Path | None = None,
+    signing_private_key_path: str | Path | None = None,
+    include_dsse: bool = False,
+    include_cyclonedx: bool = False,
+    created_utc: str | None = None,
 ) -> ReleaseBuildResult:
     """Build a deterministic release artifact.
 
@@ -75,7 +127,9 @@ def build_release(
     var = load_variants_registry(variants_path)
     rem = load_remotes_registry(remotes_path)
 
-    created = _utc_iso()
+    # Determinism: release artifacts must be byte-stable for identical inputs.
+    # Default to a fixed timestamp unless the caller explicitly overrides it.
+    created = str(created_utc) if created_utc is not None else DETERMINISTIC_CREATED_UTC
 
     manifest_obj: Dict[str, Any] = {
         "type": "fieldgrade_release/1.0",
@@ -104,14 +158,84 @@ def build_release(
     (reg_dir / "variants.json").write_text(var.canonical_json, encoding="utf-8")
     (reg_dir / "remotes.json").write_text(rem.canonical_json, encoding="utf-8")
 
-    # Deterministic zip content
-    zip_path = out_root / f"{release_id}.zip"
-    zip_files = {
+    # Optional signed attestations (DSSE) + optional deterministic CycloneDX BOM
+    zip_files: Dict[str, bytes] = {
         "manifest.json": manifest_canon.encode("utf-8"),
         "registries/components.json": comp.canonical_json.encode("utf-8"),
         "registries/variants.json": var.canonical_json.encode("utf-8"),
         "registries/remotes.json": rem.canonical_json.encode("utf-8"),
     }
+
+    if include_cyclonedx:
+        bom_obj = _build_release_cyclonedx_bom(
+            release_id=release_id,
+            manifest_sha256=manifest_sha,
+            registries={
+                "components": _registry_record(comp),
+                "variants": _registry_record(var),
+                "remotes": _registry_record(rem),
+            },
+        )
+        bom_bytes = canonical_json(bom_obj).encode("utf-8")
+        zip_files["sbom/bom.cdx.json"] = bom_bytes
+
+    if include_dsse:
+        # Keep DSSE deterministic by requiring an existing signing keypair.
+        if not signing_public_key_path or not signing_private_key_path:
+            raise ValueError("missing_signing_key_paths")
+        pub_path = Path(signing_public_key_path)
+        priv_path = Path(signing_private_key_path)
+        if not pub_path.exists() or not priv_path.exists():
+            raise ValueError("signing_key_paths_must_exist")
+
+        from termite.signing import load_private_key
+        from termite.dsse import keyid_for_pubkey_pem, make_intoto_statement, sign_dsse
+
+        pub_pem = pub_path.read_bytes()
+        kid = keyid_for_pubkey_pem(pub_pem)
+        signer = load_private_key(priv_path)
+
+        # Build DSSE: bind manifest digest
+        man_sha = _sha256_bytes(zip_files["manifest.json"])
+        build_stmt = make_intoto_statement(
+            subjects=[{"name": "manifest.json", "digest": {"sha256": man_sha}}],
+            predicate_type="https://mite.ecology/fieldgrade/release/v1",
+            predicate={
+                "release_id": release_id,
+                "manifest_sha256": manifest_sha,
+                "created_utc": created,
+            },
+        )
+        build_env = sign_dsse(
+            payload_type="application/vnd.in-toto+json",
+            payload_obj=build_stmt,
+            signer=signer,
+            keyid=kid,
+        )
+        zip_files["attestation.dsse.json"] = (canonical_json(build_env) + "\n").encode("utf-8")
+
+        # SBOM DSSE: bind CycloneDX digest if present
+        if "sbom/bom.cdx.json" in zip_files:
+            sbom_sha = _sha256_bytes(zip_files["sbom/bom.cdx.json"])
+            sbom_stmt = make_intoto_statement(
+                subjects=[{"name": "sbom/bom.cdx.json", "digest": {"sha256": sbom_sha}}],
+                predicate_type="https://mite.ecology/fieldgrade/release-sbom/v1",
+                predicate={
+                    "release_id": release_id,
+                    "created_utc": created,
+                    "sbom_format": "CycloneDX",
+                    "sbom_spec_version": "1.5",
+                },
+            )
+            sbom_env = sign_dsse(
+                payload_type="application/vnd.in-toto+json",
+                payload_obj=sbom_stmt,
+                signer=signer,
+                keyid=kid,
+            )
+            zip_files["sbom/bom.dsse.json"] = (canonical_json(sbom_env) + "\n").encode("utf-8")
+
+    zip_path = out_root / f"{release_id}.zip"
     _deterministic_zip_write(zip_path, zip_files)
 
     return ReleaseBuildResult(
@@ -137,3 +261,102 @@ def load_release_manifest(path: str | Path) -> Dict[str, Any]:
 def release_zip_sha256(path: str | Path) -> str:
     p = Path(path)
     return sha256_hex(p.read_bytes())
+
+
+def verify_release_zip(
+    *,
+    zip_path: str | Path,
+    signing_public_key_path: str | Path | None = None,
+    require_dsse: bool = False,
+    require_cyclonedx: bool = False,
+) -> Dict[str, Any]:
+    """Verify structural and cryptographic invariants of a release zip.
+
+    - Always validates manifest sha and release_id relationship.
+    - Optionally validates CycloneDX + DSSE attestations if present/required.
+    """
+    zp = Path(zip_path)
+    if not zp.exists() or not zp.is_file():
+        raise FileNotFoundError(str(zp))
+
+    with zipfile.ZipFile(zp, mode="r") as zf:
+        names = set(zf.namelist())
+        required = {
+            "manifest.json",
+            "registries/components.json",
+            "registries/variants.json",
+            "registries/remotes.json",
+        }
+        missing = sorted(required - names)
+        if missing:
+            raise ValueError(f"missing_files:{','.join(missing)}")
+
+        manifest_bytes = zf.read("manifest.json")
+        manifest_obj = json.loads(manifest_bytes.decode("utf-8"))
+        manifest_sha = sha256_str(canonical_json(manifest_obj))
+        release_id = manifest_sha[:16]
+        if zp.stem != release_id:
+            raise ValueError("release_id_mismatch")
+
+        # CycloneDX (optional)
+        has_cdx = "sbom/bom.cdx.json" in names
+        if require_cyclonedx and not has_cdx:
+            raise ValueError("missing_cyclonedx")
+
+        # DSSE (optional)
+        has_dsse = "attestation.dsse.json" in names
+        if require_dsse and not has_dsse:
+            raise ValueError("missing_dsse")
+
+        dsse_ok = False
+        sbom_dsse_ok = False
+        keyid = None
+
+        if has_dsse or ("sbom/bom.dsse.json" in names):
+            if not signing_public_key_path:
+                raise ValueError("missing_signing_public_key_path")
+            pub_path = Path(signing_public_key_path)
+            if not pub_path.exists():
+                raise ValueError("signing_public_key_not_found")
+
+            from termite.dsse import verify_dsse
+            from termite.signing import load_public_key
+
+            pub = load_public_key(pub_path)
+            keyid = _sha256_bytes(pub_path.read_bytes())
+
+            if has_dsse:
+                env = json.loads(zf.read("attestation.dsse.json").decode("utf-8"))
+                payload = verify_dsse(env, verifier=pub, expected_keyid=keyid)
+                subj = (payload.get("subject") or [])
+                if not isinstance(subj, list) or not subj:
+                    raise ValueError("dsse_payload_malformed")
+                man_digest = str(subj[0].get("digest", {}).get("sha256") or "")
+                if man_digest != _sha256_bytes(manifest_bytes):
+                    raise ValueError("dsse_manifest_digest_mismatch")
+                dsse_ok = True
+
+            if "sbom/bom.dsse.json" in names:
+                if "sbom/bom.cdx.json" not in names:
+                    raise ValueError("sbom_dsse_without_bom")
+                bom_bytes = zf.read("sbom/bom.cdx.json")
+                env = json.loads(zf.read("sbom/bom.dsse.json").decode("utf-8"))
+                payload = verify_dsse(env, verifier=pub, expected_keyid=keyid)
+                subj = (payload.get("subject") or [])
+                if not isinstance(subj, list) or not subj:
+                    raise ValueError("dsse_sbom_payload_malformed")
+                bom_digest = str(subj[0].get("digest", {}).get("sha256") or "")
+                if bom_digest != _sha256_bytes(bom_bytes):
+                    raise ValueError("dsse_sbom_digest_mismatch")
+                sbom_dsse_ok = True
+
+        return {
+            "ok": True,
+            "release_id": release_id,
+            "manifest_sha256": manifest_sha,
+            "zip_sha256": sha256_hex(zp.read_bytes()),
+            "has_cyclonedx": bool(has_cdx),
+            "dsse_ok": bool(dsse_ok),
+            "sbom_dsse_ok": bool(sbom_dsse_ok),
+            "keyid": keyid,
+        }

--- a/mite_ecology/tests/test_release_build_deterministic.py
+++ b/mite_ecology/tests/test_release_build_deterministic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import time
 
 from mite_ecology.release import build_release, release_zip_sha256
 
@@ -63,6 +64,10 @@ def test_release_build_is_deterministic(tmp_path: Path) -> None:
         variants_path=vars_,
         remotes_path=rems,
     )
+
+    # Ensure wall-clock time does not affect the artifact.
+    time.sleep(1.1)
+
     r2 = build_release(
         out_dir=out2,
         components_path=comps,

--- a/mite_ecology/tests/test_release_build_signed_verify.py
+++ b/mite_ecology/tests/test_release_build_signed_verify.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from mite_ecology.release import build_release, verify_release_zip, release_zip_sha256
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_ed25519_keypair(priv_path: Path, pub_path: Path) -> None:
+    # Deterministic test key: RFC8032-style private bytes.
+    priv = Ed25519PrivateKey.from_private_bytes(b"\x11" * 32)
+    pub = priv.public_key()
+
+    priv_bytes = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_bytes = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    priv_path.parent.mkdir(parents=True, exist_ok=True)
+    pub_path.parent.mkdir(parents=True, exist_ok=True)
+    priv_path.write_bytes(priv_bytes)
+    pub_path.write_bytes(pub_bytes)
+
+
+def test_release_build_signed_is_deterministic_and_verifiable(tmp_path: Path) -> None:
+    comps = tmp_path / "components.yaml"
+    vars_ = tmp_path / "variants.yaml"
+    rems = tmp_path / "remotes.yaml"
+
+    _write(
+        comps,
+        "\n".join(
+            [
+                "type: registry_components/1.0",
+                "version: '1.0'",
+                "components:",
+                "  - component_id: demo_component",
+            ]
+        )
+        + "\n",
+    )
+
+    _write(
+        vars_,
+        "\n".join(
+            [
+                "type: registry_variants/1.0",
+                "version: '1.0'",
+                "variants:",
+                "  - variant_id: demo_variant",
+            ]
+        )
+        + "\n",
+    )
+
+    _write(
+        rems,
+        "\n".join(
+            [
+                "type: registry_remotes/1.0",
+                "version: '1.0'",
+                "remotes: []",
+            ]
+        )
+        + "\n",
+    )
+
+    keys_dir = tmp_path / "keys"
+    priv = keys_dir / "ed25519_priv.pem"
+    pub = keys_dir / "ed25519_pub.pem"
+    _write_ed25519_keypair(priv, pub)
+
+    out1 = tmp_path / "out1"
+    out2 = tmp_path / "out2"
+
+    r1 = build_release(
+        out_dir=out1,
+        components_path=comps,
+        variants_path=vars_,
+        remotes_path=rems,
+        include_cyclonedx=True,
+        include_dsse=True,
+        signing_private_key_path=priv,
+        signing_public_key_path=pub,
+    )
+
+    time.sleep(1.1)
+
+    r2 = build_release(
+        out_dir=out2,
+        components_path=comps,
+        variants_path=vars_,
+        remotes_path=rems,
+        include_cyclonedx=True,
+        include_dsse=True,
+        signing_private_key_path=priv,
+        signing_public_key_path=pub,
+    )
+
+    assert r1.release_id == r2.release_id
+    assert release_zip_sha256(r1.zip_path) == release_zip_sha256(r2.zip_path)
+
+    rep = verify_release_zip(
+        zip_path=r1.zip_path,
+        signing_public_key_path=pub,
+        require_dsse=True,
+        require_cyclonedx=True,
+    )
+    assert rep["ok"] is True
+    assert rep["dsse_ok"] is True
+    assert rep["sbom_dsse_ok"] is True


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Add deterministic DSSE-attested release artifacts with optional CycloneDX SBOMs and provide CLI commands to build and verify releases.

New Features:
- Support building release zips with optional deterministic CycloneDX SBOMs and DSSE attestations bound to the manifest and SBOM digests.
- Expose CLI subcommands to build releases and to verify release zips, including optional enforcement of DSSE attestations and CycloneDX presence.

Enhancements:
- Ensure release artifacts are fully deterministic by fixing the created timestamp to a constant value unless explicitly overridden.
- Add a verification routine that checks release zip structure, validates manifest-derived release IDs, and cryptographically verifies DSSE envelopes when present.

Tests:
- Add tests asserting deterministic, signed release builds and successful verification of DSSE and CycloneDX invariants.