### PR TITLE
Fix: remove duplicate release-build CLI command

### DIFF
--- a/mite_ecology/mite_ecology/cli.py
+++ b/mite_ecology/mite_ecology/cli.py
@@ -352,16 +352,6 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--host-ram-mb", default=0, type=int)
     s.add_argument("--host-disk-mb", default=0, type=int)
     s.set_defaults(func=cmd_clutchscore)
-
-
-    s = sub.add_parser("release-build")
-    s.add_argument("--out", default="", help="Output directory for release artifacts (default: mite_ecology/artifacts/releases)")
-    s.add_argument("--components", default="", help="Override components registry YAML path")
-    s.add_argument("--variants", default="", help="Override variants registry YAML path")
-    s.add_argument("--remotes", default="", help="Override remotes registry YAML path")
-    s.set_defaults(func=cmd_release_build)
-
-
     return p
 
 

--- a/mite_ecology/tests/test_cli_parser.py
+++ b/mite_ecology/tests/test_cli_parser.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+def test_cli_build_parser_has_no_duplicate_subcommands() -> None:
+    # Importing and building the parser should not raise.
+    from mite_ecology.cli import build_parser
+
+    p = build_parser()
+
+    # Introspect subcommand names from argparse internals.
+    subparsers_actions = [
+        a for a in p._actions  # type: ignore[attr-defined]
+        if getattr(a, "dest", None) == "cmd"
+    ]
+    assert subparsers_actions, "expected subparsers action"
+
+    choices = getattr(subparsers_actions[0], "choices", {})
+    assert isinstance(choices, dict)
+
+    # Critical commands we expect to exist.
+    assert "release-build" in choices
+    assert "release-verify" in choices


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Remove a duplicate CLI subcommand registration and add coverage to prevent regressions.

Bug Fixes:
- Eliminate a second registration of the `release-build` CLI subcommand to avoid duplicate parser entries.

Tests:
- Add a CLI parser test that verifies there are no duplicate subcommands and that `release-build` and `release-verify` remain available.