### PR TITLE
Run UI: auto-fallback from 8787 to 8788

### DIFF
--- a/run_ui.ps1
+++ b/run_ui.ps1
@@ -12,6 +12,29 @@
 $ErrorActionPreference = "Stop"
 $ROOT = $PSScriptRoot
 
+function Test-PortInUse {
+  param(
+    [Parameter(Mandatory=$true)][int]$Port
+  )
+  try {
+    $conn = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop | Select-Object -First 1
+    return $null -ne $conn
+  } catch {
+    return $false
+  }
+}
+
+# If the caller didn't specify FG_PORT, prefer 8787 but fall back to 8788 when 8787 is occupied
+# (common on Windows when WSL/Docker port-forwarding is holding 8787).
+if (-not $env:FG_PORT -or $env:FG_PORT.Trim() -eq "") {
+  $preferred = 8787
+  if (Test-PortInUse -Port $preferred) {
+    $env:FG_PORT = "8788"
+  } else {
+    $env:FG_PORT = "$preferred"
+  }
+}
+
 $VENV = Join-Path $ROOT ".venv"
 $ACT = Join-Path $VENV "Scripts\Activate.ps1"
 
@@ -28,5 +51,7 @@ pip install -q -r (Join-Path $ROOT "requirements-dev.txt")
 pip install -q -e (Join-Path $ROOT "termite_fieldpack")
 pip install -q -e (Join-Path $ROOT "mite_ecology")
 pip install -q -e (Join-Path $ROOT "fieldgrade_ui")
+
+Write-Host "Fieldgrade UI: http://127.0.0.1:$($env:FG_PORT)/" -ForegroundColor Green
 
 python -m fieldgrade_ui serve


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Add automatic selection of the Fieldgrade UI port with a fallback and surface the selected URL when starting the UI.

New Features:
- Automatically choose FG_PORT 8787 by default and fall back to 8788 if 8787 is already in use.
- Print the Fieldgrade UI URL to the console after setup so users can easily access the running UI.