### PR TITLE
Fix catalog refresh: robust registry loader import

### DIFF
--- a/fieldgrade_ui/tests/test_releases_endpoints.py
+++ b/fieldgrade_ui/tests/test_releases_endpoints.py
@@ -143,3 +143,19 @@ def test_release_verify_requires_pubkey_when_dsse_present(client: TestClient, tm
         json={"zip_path": built["zip_path"], "require_dsse": True},
     )
     assert r.status_code == 400, r.text
+
+
+def test_registry_endpoints_ok(client: TestClient) -> None:
+    # Catalog refresh depends on these endpoints.
+    for path, key in (
+        ("/api/registry/components", "components"),
+        ("/api/registry/variants", "variants"),
+        ("/api/registry/remotes", "remotes"),
+    ):
+        r = client.get(path, headers=_h("token_a"))
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ok"] is True
+        assert body["canonical_sha256"]
+        assert isinstance(body.get("registry"), dict)
+        assert key in body["registry"]


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Make mite_ecology imports in the UI more robust across installed and workspace layouts and add coverage for registry API endpoints used by catalog refresh.

Bug Fixes:
- Handle mite_ecology modules resolving to a namespace data package by falling back to the nested mite_ecology.mite_ecology modules when necessary so registry and release-related endpoints work in both layouts.

Enhancements:
- Introduce a shared helper for importing mite_ecology submodules to centralize and harden import logic for registry, remote sync, and release operations.

Tests:
- Add tests to verify registry endpoints respond successfully with expected structure, ensuring catalog refresh prerequisites are validated.