### PR TITLE
Docs: align registry naming + graph API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 This monorepo provides:
 
+## Fieldgrade UI: API quick reference
+
+**Registry catalogs (current naming)**
+
+- The versioned JSON Schemas live under `schemas/`:
+   - `registry_components_v1.json`, `registry_variants_v1.json`, `registry_remotes_v1.json`
+- The UI/API refers to these as **registries** (not `component_catalog_v1`).
+- HTTP endpoints (return the registry payload + a deterministic `canonical_sha256`):
+   - `GET /api/registry/components`
+   - `GET /api/registry/variants`
+   - `GET /api/registry/remotes`
+
+**Knowledge graph query surface (current)**
+
+- Today, the supported HTTP query surface is the lightweight `/api/graph/*` endpoints:
+   - `GET /api/graph/nodes?filter=<substring>&limit=<n>`
+   - `GET /api/graph/neighborhood?node_id=<id>&limit_edges=<n>`
+- There is intentionally no general-purpose `/api/kg/*` surface yet.
+
 ## Canonical dev setup (recommended)
 
 Use the bootstrap scripts to get to a known-good environment (runtime + dev deps + editable installs).

--- a/docs/DEPLOY_LOCAL.md
+++ b/docs/DEPLOY_LOCAL.md
@@ -51,6 +51,12 @@ Open:
 In the UI header, paste your `FG_API_TOKEN` into **API token** and click **Set**.
 (Static `/` loads without auth; API calls require the token.)
 
+## API notes
+
+The current KG query surface exposed over HTTP is intentionally lightweight:
+- `GET /api/graph/nodes`
+- `GET /api/graph/neighborhood`
+
 ## 3) Persistent data locations
 
 Compose mounts named volumes into these in-container paths:


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Document the current registry naming and lightweight graph API surface in the README and local deployment guide.

Documentation:
- Add a quick reference in the README describing registry JSON schemas, their registry-oriented naming in the UI/API, and the associated HTTP endpoints.
- Clarify in the README and local deployment docs that the current knowledge graph is exposed via limited /api/graph endpoints and that no general-purpose /api/kg surface exists yet.