### PR TITLE
Registry: content + LDNA pinning

### DIFF
--- a/mite_ecology/mite_ecology/registry.py
+++ b/mite_ecology/mite_ecology/registry.py
@@ -108,13 +108,21 @@ def _load_registry(*, yaml_path: Path, schema_path: Path, what: str) -> Registry
 
 
 def load_components_registry(path: str | Path | None = None) -> RegistryLoadResult:
-    p = Path(path) if path is not None else (_registry_dir() / "components_v1.yaml")
+    if path is not None:
+        p = Path(path)
+    else:
+        p_new = _registry_dir() / "components.yaml"
+        p = p_new if p_new.exists() else (_registry_dir() / "components_v1.yaml")
     s = _schemas_dir() / "registry_components_v1.json"
     return _load_registry(yaml_path=p, schema_path=s, what="components_registry")
 
 
 def load_variants_registry(path: str | Path | None = None) -> RegistryLoadResult:
-    p = Path(path) if path is not None else (_registry_dir() / "variants_v1.yaml")
+    if path is not None:
+        p = Path(path)
+    else:
+        p_new = _registry_dir() / "variants.yaml"
+        p = p_new if p_new.exists() else (_registry_dir() / "variants_v1.yaml")
     s = _schemas_dir() / "registry_variants_v1.json"
     return _load_registry(yaml_path=p, schema_path=s, what="variants_registry")
 

--- a/mite_ecology/registry/components.yaml
+++ b/mite_ecology/registry/components.yaml
@@ -1,0 +1,82 @@
+type: registry_components/1.0
+version: "1.0"
+catalog_id: "ldna://yaml/registry_components@1.0.0"
+generated_at: 0
+
+components:
+  - component_id: "mitecomp://fieldgrade_ui"
+    title: "Fieldgrade UI"
+    description: "Web UI for uploading bundles, browsing jobs, inspecting outputs."
+    name: "fieldgrade_ui"
+    kind: "frontend"
+    role: "bundle_uploader"
+    runtime: "python"
+    distribution:
+      type: "python_module"
+      module: "fieldgrade_ui"
+    entrypoint: "python -m fieldgrade_ui serve"
+    constraints:
+      offline_ok: true
+      network_required: false
+    tests:
+      - name: "pytest_smoke"
+        cmd: "python -m pytest -q fieldgrade_ui"
+    provenance:
+      owner: "Xenologo"
+      license: "MIT"
+    schemas:
+      inputs:
+        - "termite_bundle"
+      outputs:
+        - "job_submission"
+        - "job_logs"
+
+  - component_id: "mitecomp://termite_fieldpack"
+    title: "Termite Fieldpack"
+    description: "Fieldpack toolchain: ingest→CAS→provenance→seal→verify→replay."
+    name: "termite"
+    kind: "backend"
+    role: "ingest+seal+verify"
+    runtime: "cli"
+    distribution:
+      type: "cli"
+      path: "termite_fieldpack/bin/termite"
+    entrypoint: "./termite_fieldpack/bin/termite"
+    policy_mode: "meap_v1"
+    policy:
+      tool_allowlist_ref: "ldna://policy/tool_allowlist@1.0.0"
+      meap_profile: "meap_v1"
+    tests:
+      - name: "fieldpack_smoke"
+        cmd: "cd termite_fieldpack && python -m pytest -q"
+    schemas:
+      outputs:
+        - "kg_delta_jsonl:ldna://json/kg_delta@1.0.0"
+        - "sealed_bundle"
+        - "sbom"
+        - "provenance_chain"
+
+  - component_id: "mitecomp://mite_ecology"
+    title: "Mite Ecology"
+    description: "Design-time pipeline: import verified bundles→KG→motifs→GA→NeuroArch export."
+    name: "mite-ecology"
+    kind: "backend"
+    role: "import+gnn+gat+ga+export"
+    runtime: "python"
+    distribution:
+      type: "python_module"
+      module: "mite_ecology"
+    entrypoint: "python -m mite_ecology.cli auto-run --cycles 3"
+    constraints:
+      offline_ok: true
+      deterministic: true
+    tests:
+      - name: "pytest"
+        cmd: "cd mite_ecology && python -m pytest -q"
+    schemas:
+      inputs:
+        - "sealed_bundle"
+        - "kg_delta_jsonl:ldna://json/kg_delta@1.0.0"
+      outputs:
+        - "motif_spec:ldna://json/motif_spec@1.0.0"
+        - "neuroarch_dsl:ldna://json/neuroarch_dsl@1.0.0"

--- a/mite_ecology/registry/components_v1.yaml
+++ b/mite_ecology/registry/components_v1.yaml
@@ -1,3 +1,82 @@
 type: registry_components/1.0
 version: "1.0"
-components: []
+catalog_id: "ldna://yaml/registry_components@1.0.0"
+generated_at: 0
+
+components:
+	- component_id: "mitecomp://fieldgrade_ui"
+		title: "Fieldgrade UI"
+		description: "Web UI for uploading bundles, browsing jobs, inspecting outputs."
+		name: "fieldgrade_ui"
+		kind: "frontend"
+		role: "bundle_uploader"
+		runtime: "python"
+		distribution:
+			type: "python_module"
+			module: "fieldgrade_ui"
+		entrypoint: "python -m fieldgrade_ui serve"
+		constraints:
+			offline_ok: true
+			network_required: false
+		tests:
+			- name: "pytest_smoke"
+				cmd: "python -m pytest -q fieldgrade_ui"
+		provenance:
+			owner: "Xenologo"
+			license: "MIT"
+		schemas:
+			inputs:
+				- "termite_bundle"
+			outputs:
+				- "job_submission"
+				- "job_logs"
+
+	- component_id: "mitecomp://termite_fieldpack"
+		title: "Termite Fieldpack"
+		description: "Fieldpack toolchain: ingest→CAS→provenance→seal→verify→replay."
+		name: "termite"
+		kind: "backend"
+		role: "ingest+seal+verify"
+		runtime: "cli"
+		distribution:
+			type: "cli"
+			path: "termite_fieldpack/bin/termite"
+		entrypoint: "./termite_fieldpack/bin/termite"
+		policy_mode: "meap_v1"
+		policy:
+			tool_allowlist_ref: "ldna://policy/tool_allowlist@1.0.0"
+			meap_profile: "meap_v1"
+		tests:
+			- name: "fieldpack_smoke"
+				cmd: "cd termite_fieldpack && python -m pytest -q"
+		schemas:
+			outputs:
+				- "kg_delta_jsonl:ldna://json/kg_delta@1.0.0"
+				- "sealed_bundle"
+				- "sbom"
+				- "provenance_chain"
+
+	- component_id: "mitecomp://mite_ecology"
+		title: "Mite Ecology"
+		description: "Design-time pipeline: import verified bundles→KG→motifs→GA→NeuroArch export."
+		name: "mite-ecology"
+		kind: "backend"
+		role: "import+gnn+gat+ga+export"
+		runtime: "python"
+		distribution:
+			type: "python_module"
+			module: "mite_ecology"
+		entrypoint: "python -m mite_ecology.cli auto-run --cycles 3"
+		constraints:
+			offline_ok: true
+			deterministic: true
+		tests:
+			- name: "pytest"
+				cmd: "cd mite_ecology && python -m pytest -q"
+		schemas:
+			inputs:
+				- "sealed_bundle"
+				- "kg_delta_jsonl:ldna://json/kg_delta@1.0.0"
+			outputs:
+				- "motif_spec:ldna://json/motif_spec@1.0.0"
+				- "neuroarch_dsl:ldna://json/neuroarch_dsl@1.0.0"

--- a/mite_ecology/registry/variants.yaml
+++ b/mite_ecology/registry/variants.yaml
@@ -1,0 +1,41 @@
+type: registry_variants/1.0
+version: "1.0"
+catalog_id: "ldna://yaml/registry_variants@1.0.0"
+generated_at: 0
+
+variants:
+  - variant_id: "mitevar://neuroarch_export@0.1.0"
+    title: "NeuroArch Export (deterministic)"
+    description: "Motif→GA derived NeuroArch DSL export + runnable skeleton."
+    lineage_tag: "neuroarch_export"
+    tags: ["neuroarch", "motif", "ga", "deterministic"]
+    device: "cpu"
+    policy_mode: "meap_v1"
+    verification:
+      meap_profile: "meap_v1"
+      tool_allowlist_ref: "ldna://policy/tool_allowlist@1.0.0"
+
+    studspec:
+      type: "studspec_v1"
+      name: "MITE_NeuroArch_Exporter"
+      version: "0.1.0"
+      components:
+        - { name: "fieldgrade_ui", kind: "frontend", role: "bundle_uploader" }
+        - { name: "termite", kind: "backend", role: "ingest+seal+verify" }
+        - { name: "mite-ecology", kind: "backend", role: "import+gnn+gat+ga+export" }
+
+    tubespec:
+      type: "tubespec_v1"
+      name: "MITE_NeuroArch_Exporter_Runtime"
+      version: "0.1.0"
+      runtime:
+        entrypoint: "python -m mite_ecology.cli auto-run --cycles 3"
+        device: "cpu"
+
+    outputs:
+      - kind: "neuroarch_dsl"
+        schema_uri: "ldna://json/neuroarch_dsl@1.0.0"
+      - kind: "motif_spec"
+        schema_uri: "ldna://json/motif_spec@1.0.0"
+
+    releases: []

--- a/mite_ecology/registry/variants_v1.yaml
+++ b/mite_ecology/registry/variants_v1.yaml
@@ -1,3 +1,41 @@
 type: registry_variants/1.0
 version: "1.0"
-variants: []
+catalog_id: "ldna://yaml/registry_variants@1.0.0"
+generated_at: 0
+
+variants:
+	- variant_id: "mitevar://neuroarch_export@0.1.0"
+		title: "NeuroArch Export (deterministic)"
+		description: "Motif→GA derived NeuroArch DSL export + runnable skeleton."
+		lineage_tag: "neuroarch_export"
+		tags: ["neuroarch", "motif", "ga", "deterministic"]
+		device: "cpu"
+		policy_mode: "meap_v1"
+		verification:
+			meap_profile: "meap_v1"
+			tool_allowlist_ref: "ldna://policy/tool_allowlist@1.0.0"
+
+		studspec:
+			type: "studspec_v1"
+			name: "MITE_NeuroArch_Exporter"
+			version: "0.1.0"
+			components:
+				- { name: "fieldgrade_ui", kind: "frontend", role: "bundle_uploader" }
+				- { name: "termite", kind: "backend", role: "ingest+seal+verify" }
+				- { name: "mite-ecology", kind: "backend", role: "import+gnn+gat+ga+export" }
+
+		tubespec:
+			type: "tubespec_v1"
+			name: "MITE_NeuroArch_Exporter_Runtime"
+			version: "0.1.0"
+			runtime:
+				entrypoint: "python -m mite_ecology.cli auto-run --cycles 3"
+				device: "cpu"
+
+		outputs:
+			- kind: "neuroarch_dsl"
+				schema_uri: "ldna://json/neuroarch_dsl@1.0.0"
+			- kind: "motif_spec"
+				schema_uri: "ldna://json/motif_spec@1.0.0"
+
+		releases: []

--- a/schemas/ldna_registry.yaml
+++ b/schemas/ldna_registry.yaml
@@ -6,16 +6,28 @@ schemas:
   description: Hypothesis list and scores
 - uri: ldna://json/kg_delta@1.0.0
   description: Knowledge graph delta operation stream
+  path: schemas/kg_delta.json
+  sha256: d0f1ee0cba98fe1c244f24e5575dd452592034dc51b8e7f79d959876c00bda76
 - uri: ldna://json/motif_spec@1.0.0
   description: Motif spec (GNN/GAT/etc) payload
+  path: schemas/motif_spec.json
+  sha256: 2a25215b1d301d250bcd147bfc8f39c14734a88397fbb9ec1690150df25e8bcf
 - uri: ldna://json/neuroarch_dsl@1.0.0
   description: Neuroarch DSL fragment
+  path: schemas/neuroarch_dsl.json
+  sha256: 9cde04f8fb1d3626811795d16783b2307acf18da640f2e3be5e3d49a8ef62e37
 - uri: ldna://yaml/registry_components@1.0.0
   description: Registry catalog (components)
+  path: schemas/registry_components_v1.json
+  sha256: 760e9fef47e03fc691dc9d69e13a44783e7806401564373c3a1f34b7e64c125e
 - uri: ldna://yaml/registry_variants@1.0.0
   description: Registry catalog (variants)
+  path: schemas/registry_variants_v1.json
+  sha256: f02bbbbb4675a7b5f35ea6f0052472861cbb123aadc616f523f868cae2b96cac
 - uri: ldna://yaml/registry_remotes@1.0.0
   description: Registry remotes configuration
+  path: schemas/registry_remotes_v1.json
+  sha256: 2b1d3be6f8fdd540479eb85a87bc028ca881c49461d3142b3f4a295225c9ec59
 compat:
   rule: major_version_compat
   notes: Consumers must accept same major; producers may emit higher minor/patch.


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Define LDNA-pinned component and variant catalogs and wire the registry loader to prefer the new catalog files while registering their schemas and content hashes.

New Features:
- Introduce populated components and variants registry catalogs with LDNA catalog IDs and schema references for the Mite ecosystem pipeline.

Enhancements:
- Update registry loading logic to prefer new components.yaml and variants.yaml catalogs while maintaining compatibility with existing *_v1.yaml files.
- Extend the LDNA registry schema index with file paths and SHA-256 hashes for JSON and registry schemas to enable content-addressable validation.