### PR TITLE
Contract: OpenAPI 3.1 + registry health

### DIFF
--- a/fieldgrade_ui/app.py
+++ b/fieldgrade_ui/app.py
@@ -8,6 +8,7 @@ import sqlite3
 import subprocess
 import sys
 import hashlib
+import yaml
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -1113,6 +1114,54 @@ def _load_registry_or_500(loader_name: str) -> Dict[str, Any]:
     }
 
 
+def _sha256_file_hex(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _ldna_registry_pin_report() -> Dict[str, Any]:
+    ldna_path = REPO_ROOT / "schemas" / "ldna_registry.yaml"
+    try:
+        raw = yaml.safe_load(ldna_path.read_text(encoding="utf-8")) or {}
+    except Exception as e:
+        return {"ok": False, "path": str(ldna_path), "error": f"load_failed: {e}", "schemas": []}
+
+    schemas = raw.get("schemas") if isinstance(raw, dict) else None
+    if not isinstance(schemas, list):
+        return {"ok": False, "path": str(ldna_path), "error": "invalid_format", "schemas": []}
+
+    out = []
+    ok = True
+    for s in schemas:
+        if not isinstance(s, dict):
+            continue
+        uri = s.get("uri")
+        rel = s.get("path")
+        expected = s.get("sha256")
+        entry: Dict[str, Any] = {"uri": uri}
+        if isinstance(rel, str) and rel:
+            p = (REPO_ROOT / rel).resolve()
+            entry["path"] = str(p)
+            if p.exists() and p.is_file() and isinstance(expected, str) and expected:
+                actual = _sha256_file_hex(p)
+                entry["sha256_expected"] = expected.lower()
+                entry["sha256_actual"] = actual.lower()
+                entry["ok"] = (entry["sha256_expected"] == entry["sha256_actual"])
+                if entry["ok"] is not True:
+                    ok = False
+            elif isinstance(expected, str) and expected:
+                entry["sha256_expected"] = expected.lower()
+                entry["ok"] = False
+                entry["error"] = "missing_file_or_unreadable"
+                ok = False
+        out.append(entry)
+
+    return {"ok": ok, "path": str(ldna_path), "schemas": out}
+
+
 @app.get("/api/registry/components")
 def registry_components(_: Request) -> Dict[str, Any]:
     return _load_registry_or_500("load_components_registry")
@@ -1126,6 +1175,34 @@ def registry_variants(_: Request) -> Dict[str, Any]:
 @app.get("/api/registry/remotes")
 def registry_remotes(_: Request) -> Dict[str, Any]:
     return _load_registry_or_500("load_remotes_registry")
+
+
+@app.get("/api/registry/health")
+def registry_health(_: Request) -> Dict[str, Any]:
+    regs: Dict[str, Any] = {}
+    overall_ok = True
+    for name, loader in (
+        ("components", "load_components_registry"),
+        ("variants", "load_variants_registry"),
+        ("remotes", "load_remotes_registry"),
+    ):
+        try:
+            payload = _load_registry_or_500(loader)
+            regs[name] = {"ok": True, "canonical_sha256": payload.get("canonical_sha256")}
+        except HTTPException as e:
+            overall_ok = False
+            regs[name] = {"ok": False, "error": e.detail}
+
+    ldna = _ldna_registry_pin_report()
+    if ldna.get("ok") is not True:
+        overall_ok = False
+
+    return {
+        "ok": overall_ok,
+        "openapi": {"version": app.openapi().get("openapi")},
+        "registries": regs,
+        "ldna_registry": ldna,
+    }
 
 
 @app.get("/api/remotes/status")

--- a/fieldgrade_ui/tests/test_releases_endpoints.py
+++ b/fieldgrade_ui/tests/test_releases_endpoints.py
@@ -173,3 +173,12 @@ def test_registry_endpoints_ok(client: TestClient) -> None:
         assert body["canonical_sha256"]
         assert isinstance(body.get("registry"), dict)
         assert key in body["registry"]
+
+
+def test_registry_health_ok(client: TestClient) -> None:
+    r = client.get("/api/registry/health", headers=_h("token_a"))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "registries" in body
+    assert "ldna_registry" in body
+    assert "openapi" in body

--- a/openapi/fieldgrade_ui.openapi.json
+++ b/openapi/fieldgrade_ui.openapi.json
@@ -1,0 +1,1349 @@
+{
+  "components": {
+    "schemas": {
+      "Body_api_pipeline_upload_run_api_pipeline_upload_run_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_api_pipeline_upload_run_api_pipeline_upload_run_post",
+        "type": "object"
+      },
+      "Body_ingest_upload_api_ingest_upload_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_ingest_upload_api_ingest_upload_post",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Fieldgrade UI",
+    "version": "0.1"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "index__get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Index"
+      }
+    },
+    "/api/bundles": {
+      "get": {
+        "operationId": "list_bundles_api_bundles_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Bundles Api Bundles Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Bundles"
+      }
+    },
+    "/api/ecology/full_pipeline": {
+      "post": {
+        "operationId": "ecology_full_pipeline_api_ecology_full_pipeline_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ecology Full Pipeline Api Ecology Full Pipeline Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ecology Full Pipeline"
+      }
+    },
+    "/api/ecology/import": {
+      "post": {
+        "operationId": "ecology_import_api_ecology_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ecology Import Api Ecology Import Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ecology Import"
+      }
+    },
+    "/api/ecology/init": {
+      "post": {
+        "operationId": "ecology_init_api_ecology_init_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ecology Init Api Ecology Init Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Ecology Init"
+      }
+    },
+    "/api/ecology/kg_validate": {
+      "get": {
+        "operationId": "ecology_kg_validate_api_ecology_kg_validate_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ecology Kg Validate Api Ecology Kg Validate Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Ecology Kg Validate"
+      }
+    },
+    "/api/ecology/replay_verify": {
+      "post": {
+        "operationId": "ecology_replay_verify_api_ecology_replay_verify_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ecology Replay Verify Api Ecology Replay Verify Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Ecology Replay Verify"
+      }
+    },
+    "/api/ecology/review_approve": {
+      "post": {
+        "operationId": "ecology_review_approve_api_ecology_review_approve_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ecology Review Approve Api Ecology Review Approve Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ecology Review Approve"
+      }
+    },
+    "/api/ecology/review_list": {
+      "post": {
+        "operationId": "ecology_review_list_api_ecology_review_list_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ecology Review List Api Ecology Review List Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ecology Review List"
+      }
+    },
+    "/api/ecology/review_reject": {
+      "post": {
+        "operationId": "ecology_review_reject_api_ecology_review_reject_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ecology Review Reject Api Ecology Review Reject Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ecology Review Reject"
+      }
+    },
+    "/api/exports": {
+      "get": {
+        "operationId": "list_exports_api_exports_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Exports Api Exports Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Exports"
+      }
+    },
+    "/api/graph/neighborhood": {
+      "get": {
+        "description": "Returns a 1-hop neighborhood subgraph for a node.\n\n`limit_edges` caps the number of edge rows returned to keep the UI responsive.",
+        "operationId": "graph_neighborhood_api_graph_neighborhood_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "node_id",
+            "required": true,
+            "schema": {
+              "title": "Node Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit_edges",
+            "required": false,
+            "schema": {
+              "default": 2000,
+              "title": "Limit Edges",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Graph Neighborhood Api Graph Neighborhood Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Graph Neighborhood"
+      }
+    },
+    "/api/graph/nodes": {
+      "get": {
+        "description": "Lightweight graph browser: returns a slice of nodes plus a suggested center node.\n\nThis endpoint is intentionally schema-tolerant: it supports both the current\n`attrs_json` payload column and older `json` payload column variants.",
+        "operationId": "graph_nodes_api_graph_nodes_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Filter",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 200,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Graph Nodes Api Graph Nodes Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Graph Nodes"
+      }
+    },
+    "/api/ingest/upload": {
+      "post": {
+        "operationId": "ingest_upload_api_ingest_upload_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ingest_upload_api_ingest_upload_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ingest Upload Api Ingest Upload Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ingest Upload"
+      }
+    },
+    "/api/jobs": {
+      "get": {
+        "operationId": "api_jobs_api_jobs_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Jobs"
+      }
+    },
+    "/api/jobs/pipeline": {
+      "post": {
+        "description": "Enqueue a full termite\u2192mite_ecology pipeline job.\n\npayload: {upload_path: str, label?: str}",
+        "operationId": "api_jobs_pipeline_api_jobs_pipeline_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Jobs Pipeline"
+      }
+    },
+    "/api/jobs/{job_id}": {
+      "get": {
+        "operationId": "api_job_api_jobs__job_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Job"
+      }
+    },
+    "/api/jobs/{job_id}/cancel": {
+      "post": {
+        "operationId": "api_job_cancel_api_jobs__job_id__cancel_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Job Cancel"
+      }
+    },
+    "/api/jobs/{job_id}/logs": {
+      "get": {
+        "operationId": "api_job_logs_api_jobs__job_id__logs_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Job Logs"
+      }
+    },
+    "/api/metrics": {
+      "get": {
+        "description": "Lightweight operational metrics (JSON).",
+        "operationId": "api_metrics_api_metrics_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Metrics"
+      }
+    },
+    "/api/pipeline/upload_run": {
+      "post": {
+        "description": "Upload a file and enqueue the pipeline as a background job.",
+        "operationId": "api_pipeline_upload_run_api_pipeline_upload_run_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "label",
+            "required": false,
+            "schema": {
+              "default": "run",
+              "title": "Label",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_api_pipeline_upload_run_api_pipeline_upload_run_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Pipeline Upload Run"
+      }
+    },
+    "/api/registry/components": {
+      "get": {
+        "operationId": "registry_components_api_registry_components_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Registry Components Api Registry Components Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Registry Components"
+      }
+    },
+    "/api/registry/health": {
+      "get": {
+        "operationId": "registry_health_api_registry_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Registry Health Api Registry Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Registry Health"
+      }
+    },
+    "/api/registry/remotes": {
+      "get": {
+        "operationId": "registry_remotes_api_registry_remotes_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Registry Remotes Api Registry Remotes Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Registry Remotes"
+      }
+    },
+    "/api/registry/variants": {
+      "get": {
+        "operationId": "registry_variants_api_registry_variants_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Registry Variants Api Registry Variants Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Registry Variants"
+      }
+    },
+    "/api/releases": {
+      "get": {
+        "operationId": "releases_list_api_releases_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Releases List Api Releases Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Releases List"
+      }
+    },
+    "/api/releases/build": {
+      "post": {
+        "operationId": "releases_build_api_releases_build_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Releases Build Api Releases Build Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Releases Build"
+      }
+    },
+    "/api/releases/verify": {
+      "post": {
+        "operationId": "releases_verify_api_releases_verify_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Releases Verify Api Releases Verify Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Releases Verify"
+      }
+    },
+    "/api/remotes/status": {
+      "get": {
+        "operationId": "remotes_status_api_remotes_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Remotes Status Api Remotes Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Remotes Status"
+      }
+    },
+    "/api/remotes/sync": {
+      "post": {
+        "operationId": "remotes_sync_api_remotes_sync_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "remote_id",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Remote Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Remotes Sync Api Remotes Sync Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remotes Sync"
+      }
+    },
+    "/api/state": {
+      "get": {
+        "operationId": "state_api_state_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response State Api State Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "State"
+      }
+    },
+    "/api/termite/ingest": {
+      "post": {
+        "operationId": "termite_ingest_api_termite_ingest_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Termite Ingest Api Termite Ingest Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Termite Ingest"
+      }
+    },
+    "/api/termite/replay": {
+      "post": {
+        "operationId": "termite_replay_api_termite_replay_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Termite Replay Api Termite Replay Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Termite Replay"
+      }
+    },
+    "/api/termite/seal": {
+      "post": {
+        "operationId": "termite_seal_api_termite_seal_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Termite Seal Api Termite Seal Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Termite Seal"
+      }
+    },
+    "/api/termite/spec_validate": {
+      "post": {
+        "operationId": "termite_spec_validate_api_termite_spec_validate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Termite Spec Validate Api Termite Spec Validate Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Termite Spec Validate"
+      }
+    },
+    "/api/termite/verify": {
+      "post": {
+        "operationId": "termite_verify_api_termite_verify_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Termite Verify Api Termite Verify Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Termite Verify"
+      }
+    },
+    "/healthz": {
+      "get": {
+        "operationId": "healthz_healthz_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Healthz Healthz Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Healthz"
+      }
+    },
+    "/readyz": {
+      "get": {
+        "description": "Readiness probe.\n\nConservative: do not create or migrate DBs here; only confirm required state\nexists on disk.",
+        "operationId": "readyz_readyz_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Readyz"
+      }
+    }
+  }
+}

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    # fg_next/scripts/export_openapi.py -> fg_next
+    return Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    repo = _repo_root()
+    sys.path.insert(0, str(repo))
+
+    from fieldgrade_ui.app import app  # noqa: WPS433
+
+    schema = app.openapi()
+    out_dir = repo / "openapi"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "fieldgrade_ui.openapi.json"
+
+    out_path.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(str(out_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Add a registry health endpoint and introduce OpenAPI schema export for the UI service.

New Features:
- Expose a /api/registry/health endpoint reporting registry load status, LDNA registry pin integrity, and the service OpenAPI version.
- Provide a script to export the FastAPI OpenAPI schema to a versioned JSON file in the repository.

Tests:
- Add an integration test ensuring the registry health endpoint responds successfully and includes expected top-level keys.