### PR TITLE
Laptop mode llm runtime

### DIFF
--- a/.github/workflows/deploy_vps.yml
+++ b/.github/workflows/deploy_vps.yml
@@ -81,9 +81,41 @@ jobs:
             set -euo pipefail
             cd '${DEPLOY_PATH}'
 
-            git fetch --all --prune
-            git checkout '${REF}'
-            git pull --ff-only origin '${REF}' || true
+            # Deploy deterministically: resolve REF (branch/tag/SHA) to a commit SHA,
+            # then checkout that commit in detached HEAD mode.
+            git fetch --prune origin
+
+            ref_raw='${REF}'
+            ref_in=\"${ref_raw}\"
+            ref_in=\"${ref_in#refs/heads/}\"
+            ref_in=\"${ref_in#refs/tags/}\"
+            ref_in=\"${ref_in#origin/}\"
+
+            # Refuse to deploy if tracked files are locally modified.
+            if ! git diff --quiet; then
+              echo 'ERROR: tracked files modified in working tree; refusing deploy.' >&2
+              git status --porcelain >&2 || true
+              exit 3
+            fi
+
+            target=''
+            if git show-ref --verify --quiet \"refs/remotes/origin/${ref_in}\"; then
+              target=\"refs/remotes/origin/${ref_in}\"
+            elif git show-ref --verify --quiet \"refs/tags/${ref_in}\"; then
+              target=\"refs/tags/${ref_in}\"
+            elif git rev-parse --verify --quiet \"${ref_raw}^{commit}\" >/dev/null; then
+              target=\"${ref_raw}^{commit}\"
+            elif git rev-parse --verify --quiet \"${ref_in}^{commit}\" >/dev/null; then
+              target=\"${ref_in}^{commit}\"
+            else
+              echo \"ERROR: unable to resolve ref '${ref_raw}' (branch/tag/SHA not found)\" >&2
+              exit 2
+            fi
+
+            sha=\"$(git rev-parse \"${target}\")\"
+            echo \"Deploying REF='${ref_raw}' -> SHA=${sha}\"
+            git checkout --detach \"${sha}\"
+            echo \"Checked out SHA=$(git rev-parse HEAD)\"
 
             docker compose ${compose_args} config >/dev/null
             docker compose ${compose_args} up -d --build

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,9 +30,17 @@ services:
       context: .
       dockerfile: Dockerfile
     command: ["python", "-m", "fieldgrade_ui", "worker"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import json, os, sys, time; p='/app/fieldgrade_ui/runtime/worker_heartbeat.json'; max_age=float(os.environ.get('FG_WORKER_HEARTBEAT_MAX_AGE_S','30'));\n\ntry:\n  hb=json.load(open(p,'r',encoding='utf-8'))\n  ts=float(hb.get('ts',0))\n  age=time.time()-ts\n  sys.exit(0 if age <= max_age else 1)\nexcept Exception:\n  sys.exit(1)\n"]
+      interval: 15s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
     environment:
       FG_WORKER_POLL: "${FG_WORKER_POLL:-1.0}"
       FG_CMD_TIMEOUT_S: "${FG_CMD_TIMEOUT_S:-600}"
+      FG_WORKER_HEARTBEAT_INTERVAL_S: "${FG_WORKER_HEARTBEAT_INTERVAL_S:-5}"
+      FG_WORKER_HEARTBEAT_MAX_AGE_S: "${FG_WORKER_HEARTBEAT_MAX_AGE_S:-30}"
     volumes:
       - fg_termite_runtime:/app/termite_fieldpack/runtime
       - fg_termite_artifacts:/app/termite_fieldpack/artifacts

--- a/docs/LLM_RUNTIME.md
+++ b/docs/LLM_RUNTIME.md
@@ -1,0 +1,44 @@
+# LLM Runtime (Laptop Mode)
+
+Fieldgrade’s “laptop mode” runs an OpenAI-compatible LLM server that is **owned and controlled by Termite**.
+
+The goal is one-button reliability:
+- Termite can `start/stop/status/ping` a local OpenAI-compatible server.
+- The active endpoint identity is persisted in `termite_fieldpack/runtime/llm/active_endpoint.json`.
+- `termite llm chat` prefers the active endpoint when it is running.
+- `mite_ecology llm-sync` can bind to the Termite endpoint via `endpoint_source: termite`.
+
+## Quickstart
+
+1) Edit `termite_fieldpack/config/termite.yaml`:
+
+- Keep safe default (manual operator-run server):
+  - `llm.provider: endpoint_only`
+  - `llm.launch.enabled: false`
+
+- Laptop mode:
+  - Set `llm.launch.enabled: true`
+  - Set `llm.model` (required)
+  - Set `llm.host`/`llm.port` (defaults: `127.0.0.1:8789`)
+  - Provide either:
+    - `llm.launch.command` (recommended, cross-platform), or
+    - `llm.provider: llama_cpp_server|vllm` to use a template command.
+
+2) Start the server:
+
+- `python -m termite.cli llm start`
+
+3) Check status and readiness:
+
+- `python -m termite.cli llm status --json`
+- `python -m termite.cli llm ping`
+
+4) Stop:
+
+- `python -m termite.cli llm stop`
+
+## Notes
+
+- Readiness uses `GET /v1/models` (OpenAI-compatible).
+- On Windows, stop uses a `taskkill` fallback to avoid stale PID state.
+- The state file is written atomically to avoid partially-written JSON.

--- a/fieldgrade_ui/static/index.html
+++ b/fieldgrade_ui/static/index.html
@@ -32,6 +32,7 @@
     <button type="button" class="tab" data-panel="bundles">Bundles</button>
     <button type="button" class="tab" data-panel="ecology">Ecology</button>
     <button type="button" class="tab" data-panel="jobs">Jobs</button>
+    <button type="button" class="tab" data-panel="llm">LLM</button>
     <button type="button" class="tab" data-panel="catalog">Catalog</button>
     <button type="button" class="tab" data-panel="graph">Graph Explorer</button>
     <button type="button" class="tab" data-panel="logs">Logs</button>
@@ -213,6 +214,36 @@
       <div class="card">
         <h3>Logs</h3>
         <div id="jobLogs" class="mono small pre"></div>
+      </div>
+    </section>
+
+    <section class="panel" id="panel-llm">
+      <h2>LLM</h2>
+      <p class="hint">Laptop-mode local OpenAI-compatible server control (Termite-owned runtime).</p>
+
+      <div class="grid2">
+        <div class="card">
+          <h3>Controls</h3>
+          <div class="row">
+            <button type="button" id="btnLLMStart">Start</button>
+            <button type="button" id="btnLLMStop" class="danger">Stop</button>
+            <button type="button" id="btnLLMPing">Ping</button>
+            <button type="button" id="btnLLMRefresh">Refresh</button>
+          </div>
+          <div class="kv">
+            <div class="k">Status</div>
+            <div class="v mono" id="llmSummary">(unknown)</div>
+          </div>
+          <div class="kv">
+            <div class="k">Last error</div>
+            <div class="v mono" id="llmLastError">(none)</div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3>Raw status</h3>
+          <pre id="llmStatusPre" class="mono small pre"></pre>
+        </div>
       </div>
     </section>
 

--- a/fieldgrade_ui/tests/test_worker_status_endpoint.py
+++ b/fieldgrade_ui/tests/test_worker_status_endpoint.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _h(token: str) -> dict[str, str]:
+    return {"X-API-Key": token}
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("FG_API_TOKENS", "token_a,token_b")
+
+    # Isolated jobs DB per test.
+    monkeypatch.setenv("FG_JOBS_DB", str(tmp_path / "jobs.sqlite"))
+
+    # Keep termite artifacts out of the repo tree for tests.
+    monkeypatch.setenv("FG_TERMITE_ARTIFACTS_DIR", str(tmp_path / "termite_artifacts"))
+
+    # Tenant runtime root isolated per test.
+    monkeypatch.setenv("FG_TENANTS_ROOT", str(tmp_path / "tenants"))
+
+    # UI runtime isolated per test (used by worker heartbeat path).
+    monkeypatch.setenv("FG_UI_RUNTIME_DIR", str(tmp_path / "ui_runtime"))
+
+    import fieldgrade_ui.app as app_mod
+
+    importlib.reload(app_mod)
+    return TestClient(app_mod.app)  # type: ignore[attr-defined]
+
+
+def test_worker_status_endpoint_ok_shape(client: TestClient) -> None:
+    r = client.get("/api/worker/status", headers=_h("token_a"))
+    assert r.status_code == 200
+    data = r.json()
+
+    assert "ok" in data
+    assert "reason" in data
+    assert "heartbeat_path" in data
+    assert "max_age_s" in data

--- a/mite_ecology/registry/components_v1.yaml
+++ b/mite_ecology/registry/components_v1.yaml
@@ -4,79 +4,79 @@ catalog_id: "ldna://yaml/registry_components@1.0.0"
 generated_at: 0
 
 components:
-	- component_id: "mitecomp://fieldgrade_ui"
-		title: "Fieldgrade UI"
-		description: "Web UI for uploading bundles, browsing jobs, inspecting outputs."
-		name: "fieldgrade_ui"
-		kind: "frontend"
-		role: "bundle_uploader"
-		runtime: "python"
-		distribution:
-			type: "python_module"
-			module: "fieldgrade_ui"
-		entrypoint: "python -m fieldgrade_ui serve"
-		constraints:
-			offline_ok: true
-			network_required: false
-		tests:
-			- name: "pytest_smoke"
-				cmd: "python -m pytest -q fieldgrade_ui"
-		provenance:
-			owner: "Xenologo"
-			license: "MIT"
-		schemas:
-			inputs:
-				- "termite_bundle"
-			outputs:
-				- "job_submission"
-				- "job_logs"
+  - component_id: "mitecomp://fieldgrade_ui"
+    title: "Fieldgrade UI"
+    description: "Web UI for uploading bundles, browsing jobs, inspecting outputs."
+    name: "fieldgrade_ui"
+    kind: "frontend"
+    role: "bundle_uploader"
+    runtime: "python"
+    distribution:
+      type: "python_module"
+      module: "fieldgrade_ui"
+    entrypoint: "python -m fieldgrade_ui serve"
+    constraints:
+      offline_ok: true
+      network_required: false
+    tests:
+      - name: "pytest_smoke"
+        cmd: "python -m pytest -q fieldgrade_ui"
+    provenance:
+      owner: "Xenologo"
+      license: "MIT"
+    schemas:
+      inputs:
+        - "termite_bundle"
+      outputs:
+        - "job_submission"
+        - "job_logs"
 
-	- component_id: "mitecomp://termite_fieldpack"
-		title: "Termite Fieldpack"
-		description: "Fieldpack toolchain: ingest→CAS→provenance→seal→verify→replay."
-		name: "termite"
-		kind: "backend"
-		role: "ingest+seal+verify"
-		runtime: "cli"
-		distribution:
-			type: "cli"
-			path: "termite_fieldpack/bin/termite"
-		entrypoint: "./termite_fieldpack/bin/termite"
-		policy_mode: "meap_v1"
-		policy:
-			tool_allowlist_ref: "ldna://policy/tool_allowlist@1.0.0"
-			meap_profile: "meap_v1"
-		tests:
-			- name: "fieldpack_smoke"
-				cmd: "cd termite_fieldpack && python -m pytest -q"
-		schemas:
-			outputs:
-				- "kg_delta_jsonl:ldna://json/kg_delta@1.0.0"
-				- "sealed_bundle"
-				- "sbom"
-				- "provenance_chain"
+  - component_id: "mitecomp://termite_fieldpack"
+    title: "Termite Fieldpack"
+    description: "Fieldpack toolchain: ingest→CAS→provenance→seal→verify→replay."
+    name: "termite"
+    kind: "backend"
+    role: "ingest+seal+verify"
+    runtime: "cli"
+    distribution:
+      type: "cli"
+      path: "termite_fieldpack/bin/termite"
+    entrypoint: "./termite_fieldpack/bin/termite"
+    policy_mode: "meap_v1"
+    policy:
+      tool_allowlist_ref: "ldna://policy/tool_allowlist@1.0.0"
+      meap_profile: "meap_v1"
+    tests:
+      - name: "fieldpack_smoke"
+        cmd: "cd termite_fieldpack && python -m pytest -q"
+    schemas:
+      outputs:
+        - "kg_delta_jsonl:ldna://json/kg_delta@1.0.0"
+        - "sealed_bundle"
+        - "sbom"
+        - "provenance_chain"
 
-	- component_id: "mitecomp://mite_ecology"
-		title: "Mite Ecology"
-		description: "Design-time pipeline: import verified bundles→KG→motifs→GA→NeuroArch export."
-		name: "mite-ecology"
-		kind: "backend"
-		role: "import+gnn+gat+ga+export"
-		runtime: "python"
-		distribution:
-			type: "python_module"
-			module: "mite_ecology"
-		entrypoint: "python -m mite_ecology.cli auto-run --cycles 3"
-		constraints:
-			offline_ok: true
-			deterministic: true
-		tests:
-			- name: "pytest"
-				cmd: "cd mite_ecology && python -m pytest -q"
-		schemas:
-			inputs:
-				- "sealed_bundle"
-				- "kg_delta_jsonl:ldna://json/kg_delta@1.0.0"
-			outputs:
-				- "motif_spec:ldna://json/motif_spec@1.0.0"
-				- "neuroarch_dsl:ldna://json/neuroarch_dsl@1.0.0"
+  - component_id: "mitecomp://mite_ecology"
+    title: "Mite Ecology"
+    description: "Design-time pipeline: import verified bundles→KG→motifs→GA→NeuroArch export."
+    name: "mite-ecology"
+    kind: "backend"
+    role: "import+gnn+gat+ga+export"
+    runtime: "python"
+    distribution:
+      type: "python_module"
+      module: "mite_ecology"
+    entrypoint: "python -m mite_ecology.cli auto-run --cycles 3"
+    constraints:
+      offline_ok: true
+      deterministic: true
+    tests:
+      - name: "pytest"
+        cmd: "cd mite_ecology && python -m pytest -q"
+    schemas:
+      inputs:
+        - "sealed_bundle"
+        - "kg_delta_jsonl:ldna://json/kg_delta@1.0.0"
+      outputs:
+        - "motif_spec:ldna://json/motif_spec@1.0.0"
+        - "neuroarch_dsl:ldna://json/neuroarch_dsl@1.0.0"

--- a/mite_ecology/registry/variants_v1.yaml
+++ b/mite_ecology/registry/variants_v1.yaml
@@ -4,38 +4,38 @@ catalog_id: "ldna://yaml/registry_variants@1.0.0"
 generated_at: 0
 
 variants:
-	- variant_id: "mitevar://neuroarch_export@0.1.0"
-		title: "NeuroArch Export (deterministic)"
-		description: "Motif→GA derived NeuroArch DSL export + runnable skeleton."
-		lineage_tag: "neuroarch_export"
-		tags: ["neuroarch", "motif", "ga", "deterministic"]
-		device: "cpu"
-		policy_mode: "meap_v1"
-		verification:
-			meap_profile: "meap_v1"
-			tool_allowlist_ref: "ldna://policy/tool_allowlist@1.0.0"
+  - variant_id: "mitevar://neuroarch_export@0.1.0"
+    title: "NeuroArch Export (deterministic)"
+    description: "Motif→GA derived NeuroArch DSL export + runnable skeleton."
+    lineage_tag: "neuroarch_export"
+    tags: ["neuroarch", "motif", "ga", "deterministic"]
+    device: "cpu"
+    policy_mode: "meap_v1"
+    verification:
+      meap_profile: "meap_v1"
+      tool_allowlist_ref: "ldna://policy/tool_allowlist@1.0.0"
 
-		studspec:
-			type: "studspec_v1"
-			name: "MITE_NeuroArch_Exporter"
-			version: "0.1.0"
-			components:
-				- { name: "fieldgrade_ui", kind: "frontend", role: "bundle_uploader" }
-				- { name: "termite", kind: "backend", role: "ingest+seal+verify" }
-				- { name: "mite-ecology", kind: "backend", role: "import+gnn+gat+ga+export" }
+    studspec:
+      type: "studspec_v1"
+      name: "MITE_NeuroArch_Exporter"
+      version: "0.1.0"
+      components:
+        - { name: "fieldgrade_ui", kind: "frontend", role: "bundle_uploader" }
+        - { name: "termite", kind: "backend", role: "ingest+seal+verify" }
+        - { name: "mite-ecology", kind: "backend", role: "import+gnn+gat+ga+export" }
 
-		tubespec:
-			type: "tubespec_v1"
-			name: "MITE_NeuroArch_Exporter_Runtime"
-			version: "0.1.0"
-			runtime:
-				entrypoint: "python -m mite_ecology.cli auto-run --cycles 3"
-				device: "cpu"
+    tubespec:
+      type: "tubespec_v1"
+      name: "MITE_NeuroArch_Exporter_Runtime"
+      version: "0.1.0"
+      runtime:
+        entrypoint: "python -m mite_ecology.cli auto-run --cycles 3"
+        device: "cpu"
 
-		outputs:
-			- kind: "neuroarch_dsl"
-				schema_uri: "ldna://json/neuroarch_dsl@1.0.0"
-			- kind: "motif_spec"
-				schema_uri: "ldna://json/motif_spec@1.0.0"
+    outputs:
+      - kind: "neuroarch_dsl"
+        schema_uri: "ldna://json/neuroarch_dsl@1.0.0"
+      - kind: "motif_spec"
+        schema_uri: "ldna://json/motif_spec@1.0.0"
 
-		releases: []
+    releases: []

--- a/termite_fieldpack/__init__.py
+++ b/termite_fieldpack/__init__.py
@@ -1,0 +1,6 @@
+"""Helper package namespace for repo-local tests/support modules.
+
+This package is not part of the distributed termite-fieldpack wheel (only `termite` is).
+It exists so `python -m termite_fieldpack.tests.support.fake_openai_server` works in
+repo/CI.
+"""

--- a/termite_fieldpack/config/termite.yaml
+++ b/termite_fieldpack/config/termite.yaml
@@ -45,8 +45,47 @@ llm:
     timeout_s: 3
   launch:
     enabled: false
-    # Example llama.cpp server contract (you supply the binary + weights):
-    # command: ["./llama-server","-m","./models/qwen2.5-coder-0.5b-instruct.gguf","--host","127.0.0.1","--port","8000"]
+    # ----------------------------------------------------------------------
+    # LAPTOP MODE (examples)
+    #
+    # Termite can start a local OpenAI-compatible server and persist the active
+    # endpoint identity under runtime/llm/active_endpoint.json.
+    #
+    # Provider: llama_cpp_server
+    #   OpenAI-compatible endpoint via llama.cpp "llama-server".
+    #   You supply the binary and weights (operator-managed download).
+    #
+    # provider: "llama_cpp_server"
+    # host: "127.0.0.1"
+    # port: 8789
+    # model: "qwen2.5-coder-0.5b-instruct"
+    # model_path: "./models/qwen2.5-coder-0.5b-instruct.gguf"
+    # launch:
+    #   enabled: true
+    #   command: ["llama-server","-m","./models/qwen2.5-coder-0.5b-instruct.gguf","--host","127.0.0.1","--port","8789"]
+    #
+    # Provider: vllm
+    #   OpenAI-compatible endpoint via vLLM API server.
+    #   You supply the model (local path or HF id) and have vLLM installed.
+    #
+    # provider: "vllm"
+    # host: "127.0.0.1"
+    # port: 8789
+    # model: "qwen2.5-coder-0.5b-instruct"
+    # model_path: "./models/qwen2.5-coder-0.5b-instruct"   # optional
+    # launch:
+    #   enabled: true
+    #   command:
+    #     - "python"
+    #     - "-m"
+    #     - "vllm.entrypoints.openai.api_server"
+    #     - "--host"
+    #     - "127.0.0.1"
+    #     - "--port"
+    #     - "8789"
+    #     - "--model"
+    #     - "./models/qwen2.5-coder-0.5b-instruct"
+    # ----------------------------------------------------------------------
     command: []
     cwd: "./runtime/llm"      # relative to runtime_root
     env: {}

--- a/termite_fieldpack/termite/cli.py
+++ b/termite_fieldpack/termite/cli.py
@@ -19,7 +19,7 @@ from .bundle import SealInputs, build_bundle
 from .policy import load_policy, canonical_hash_dict
 from .verify import verify_bundle
 from .replay import replay_bundle
-from .llm_runtime import start as llm_start, stop as llm_stop, ping as llm_ping, read_status as llm_status
+from .llm_runtime import start_llm as llm_start, stop_llm as llm_stop, ping_llm as llm_ping, status_llm as llm_status
 from .llm_chat import chat as llm_chat
 from .tools import run_tool
 from .mission import run_mission
@@ -138,22 +138,22 @@ def cmd_replay(args) -> int:
 def cmd_llm_start(args) -> int:
     cfg = load_config(args.config)
     st = llm_start(cfg, force=args.force)
-    print(json.dumps(st.__dict__, indent=2, sort_keys=True))
+    print(json.dumps(st, indent=2, sort_keys=True))
     return 0
 
 
 def cmd_llm_stop(args) -> int:
     cfg = load_config(args.config)
     st = llm_stop(cfg, force_kill=args.force_kill)
-    print(json.dumps(st.__dict__, indent=2, sort_keys=True))
+    print(json.dumps(st, indent=2, sort_keys=True))
     return 0
 
 
 def cmd_llm_ping(args) -> int:
     cfg = load_config(args.config)
-    ok, msg = llm_ping(cfg)
-    print(json.dumps({"ok": bool(ok), "msg": msg}, indent=2, sort_keys=True))
-    return 0 if ok else 2
+    out = llm_ping(cfg)
+    print(json.dumps(out, indent=2, sort_keys=True))
+    return 0 if out.get("ok") else 2
 
 
 def cmd_llm_status(args) -> int:

--- a/termite_fieldpack/termite/config.py
+++ b/termite_fieldpack/termite/config.py
@@ -1,18 +1,142 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass, field
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 import yaml
 
 def _expand(p: str) -> str:
     return os.path.expandvars(os.path.expanduser(p))
 
+
+@dataclass(frozen=True)
+class LLMLaunchConfig:
+    enabled: bool = False
+    # Accept either a string (shell-ish) or a list of argv tokens.
+    command: Union[str, List[str], None] = None
+    env: Dict[str, str] = field(default_factory=dict)
+    cwd: Optional[str] = None
+    startup_timeout_seconds: float = 30.0
+    kill_timeout_seconds: float = 10.0
+
+
+@dataclass(frozen=True)
+class LLMConfig:
+    provider: str = "endpoint_only"
+
+    # OpenAI-compatible base URL (preferred). If absent, it will be derived from host/port.
+    base_url: str = ""
+
+    # Model identifier (required for laptop launch mode).
+    model: str = ""
+
+    # Optional local model path (recommended in laptop mode when the server requires weights).
+    model_path: Optional[str] = None
+
+    host: str = "127.0.0.1"
+    port: int = 8789
+
+    offline_loopback_only: bool = True
+
+    ping_path: str = "/v1/models"
+    ping_timeout_s: float = 3.0
+
+    launch: LLMLaunchConfig = field(default_factory=LLMLaunchConfig)
+
+
 @dataclass(frozen=True)
 class TermiteConfig:
     raw: Dict[str, Any]
+
+    # -------------------------
+    # Structured LLM config (backward compatible)
+    # -------------------------
+    @property
+    def llm(self) -> LLMConfig:
+        llm_raw = dict(self.raw.get("llm", {}) or {})
+
+        provider = str(llm_raw.get("provider") or "endpoint_only")
+        model = str(llm_raw.get("model") or "")
+        model_path = llm_raw.get("model_path")
+        model_path_s = str(model_path) if model_path is not None and str(model_path).strip() else None
+
+        host = str(llm_raw.get("host") or "127.0.0.1")
+        try:
+            port = int(llm_raw.get("port") or 8789)
+        except Exception:
+            port = 8789
+
+        # Backward compatibility: endpoint_base_url was the original name.
+        base_url = str(llm_raw.get("endpoint_base_url") or llm_raw.get("base_url") or "").strip()
+        if not base_url:
+            base_url = f"http://{host}:{port}"
+
+        offline_loopback_only = bool(llm_raw.get("offline_loopback_only", True))
+        ping_raw = dict(llm_raw.get("ping", {}) or {})
+        ping_path = str(ping_raw.get("path") or "/v1/models")
+        try:
+            ping_timeout_s = float(ping_raw.get("timeout_s") or 3.0)
+        except Exception:
+            ping_timeout_s = 3.0
+
+        launch_raw = dict(llm_raw.get("launch", {}) or {})
+        enabled = bool(launch_raw.get("enabled", False))
+
+        command: Union[str, List[str], None]
+        cmd_raw = launch_raw.get("command")
+        if cmd_raw is None:
+            command = None
+        elif isinstance(cmd_raw, str):
+            command = cmd_raw
+        elif isinstance(cmd_raw, list) and all(isinstance(x, str) for x in cmd_raw):
+            command = list(cmd_raw)
+        else:
+            # Preserve backwards-compatibility by treating invalid command types as absent.
+            command = None
+
+        env_raw = launch_raw.get("env") or {}
+        env: Dict[str, str] = {}
+        if isinstance(env_raw, Mapping):
+            for k, v in env_raw.items():
+                env[str(k)] = str(v)
+
+        cwd = launch_raw.get("cwd")
+        cwd_s = str(cwd) if cwd is not None and str(cwd).strip() else None
+
+        # Backward compatibility: older configs used *_timeout_s.
+        st_raw = launch_raw.get("startup_timeout_seconds", launch_raw.get("startup_timeout_s", 30))
+        kt_raw = launch_raw.get("kill_timeout_seconds", launch_raw.get("stop_timeout_s", 10))
+        try:
+            startup_timeout_seconds = float(st_raw)
+        except Exception:
+            startup_timeout_seconds = 30.0
+        try:
+            kill_timeout_seconds = float(kt_raw)
+        except Exception:
+            kill_timeout_seconds = 10.0
+
+        return LLMConfig(
+            provider=provider,
+            base_url=base_url,
+            model=model,
+            model_path=model_path_s,
+            host=host,
+            port=port,
+            offline_loopback_only=offline_loopback_only,
+            ping_path=ping_path,
+            ping_timeout_s=ping_timeout_s,
+            launch=LLMLaunchConfig(
+                enabled=enabled,
+                command=command,
+                env=env,
+                cwd=cwd_s,
+                startup_timeout_seconds=startup_timeout_seconds,
+                kill_timeout_seconds=kill_timeout_seconds,
+            ),
+        )
 
     # -------------------------
     # Core paths
@@ -133,51 +257,70 @@ class TermiteConfig:
     # -------------------------
     @property
     def llm_provider(self) -> str:
-        return str(self.raw.get("llm", {}).get("provider", "endpoint_only"))
+        return self.llm.provider
 
     @property
     def llm_endpoint_base_url(self) -> str:
-        return str(self.raw.get("llm", {}).get("endpoint_base_url", ""))
+        # Keep legacy name for compatibility (endpoint_base_url).
+        return str((self.raw.get("llm", {}) or {}).get("endpoint_base_url") or "")
+
+    @property
+    def llm_base_url(self) -> str:
+        return self.llm.base_url
+
+    @property
+    def llm_host(self) -> str:
+        return self.llm.host
+
+    @property
+    def llm_port(self) -> int:
+        return int(self.llm.port)
+
+    @property
+    def llm_model_path(self) -> str:
+        return str(self.llm.model_path or "")
 
     @property
     def llm_model(self) -> str:
-        return str(self.raw.get("llm", {}).get("model", ""))
+        return self.llm.model
 
     @property
     def llm_offline_loopback_only(self) -> bool:
-        return bool(self.raw.get("llm", {}).get("offline_loopback_only", True))
+        return bool(self.llm.offline_loopback_only)
 
     @property
     def llm_ping_path(self) -> str:
-        return str(self.raw.get("llm", {}).get("ping", {}).get("path", "/v1/models"))
+        return self.llm.ping_path
 
     @property
     def llm_ping_timeout_s(self) -> int:
-        return int(self.raw.get("llm", {}).get("ping", {}).get("timeout_s", 3))
+        return int(self.llm.ping_timeout_s)
 
     @property
     def llm_launch_enabled(self) -> bool:
-        return bool(self.raw.get("llm", {}).get("launch", {}).get("enabled", False))
+        return bool(self.llm.launch.enabled)
 
     @property
     def llm_launch_command(self) -> list[str]:
-        return list(self.raw.get("llm", {}).get("launch", {}).get("command", []))
+        cmd = self.llm.launch.command
+        return list(cmd) if isinstance(cmd, list) else []
 
     @property
     def llm_launch_cwd(self) -> Path:
-        return Path(_expand(self.raw.get("llm", {}).get("launch", {}).get("cwd", str(self.runtime_root / "llm")))).resolve()
+        cwd = self.llm.launch.cwd or str(self.runtime_root / "llm")
+        return Path(_expand(str(cwd))).resolve()
 
     @property
     def llm_launch_env(self) -> Dict[str, str]:
-        return dict(self.raw.get("llm", {}).get("launch", {}).get("env", {}))
+        return dict(self.llm.launch.env)
 
     @property
     def llm_startup_timeout_s(self) -> int:
-        return int(self.raw.get("llm", {}).get("launch", {}).get("startup_timeout_s", 30))
+        return int(self.llm.launch.startup_timeout_seconds)
 
     @property
     def llm_stop_timeout_s(self) -> int:
-        return int(self.raw.get("llm", {}).get("launch", {}).get("stop_timeout_s", 10))
+        return int(self.llm.launch.kill_timeout_seconds)
 
 
 def default_config_path() -> Path:

--- a/termite_fieldpack/termite/llm_runtime.py
+++ b/termite_fieldpack/termite/llm_runtime.py
@@ -273,11 +273,10 @@ def _spawn_process(cfg: TermiteConfig, argv: List[str], *, cwd: Path, env: Dict[
     # Stream stdout/stderr to a single log file.
     out = logf.open("ab")
     popen_kwargs["stdout"] = out
-    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
     # Termite intentionally launches a local OpenAI-compatible server. The argv
     # comes from operator-controlled config (or a fixed template), and we
     # explicitly avoid shell=True.
-    p = subprocess.Popen(argv, **popen_kwargs)
+    p = subprocess.Popen(argv, **popen_kwargs)  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
     return p
 
 

--- a/termite_fieldpack/termite/llm_runtime.py
+++ b/termite_fieldpack/termite/llm_runtime.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import json
 import os
 import signal
+import shlex
 import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
 
@@ -28,6 +29,10 @@ class LLMRuntimeStatus:
     started_utc: Optional[str]
     state_path: str
     endpoint_id: str
+
+
+def _now_ts() -> float:
+    return time.time()
 
 
 def _llm_dir(cfg: TermiteConfig) -> Path:
@@ -57,45 +62,76 @@ def _read_cfg_llm(raw: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _effective_base_url(cfg: TermiteConfig) -> str:
-    llm = _read_cfg_llm(cfg.raw)
-    return str(llm.get("endpoint_base_url") or llm.get("base_url") or "http://127.0.0.1:8000")
+    # Prefer structured config; keep legacy keys for compatibility.
+    try:
+        base = (cfg.llm.base_url or "").strip()
+        if base:
+            return base
+        return f"http://{cfg.llm.host}:{cfg.llm.port}"
+    except Exception:
+        llm = _read_cfg_llm(cfg.raw)
+        host = str(llm.get("host") or "127.0.0.1")
+        port = int(llm.get("port") or 8789)
+        return str(llm.get("endpoint_base_url") or llm.get("base_url") or f"http://{host}:{port}")
 
 
 def _effective_model(cfg: TermiteConfig) -> str:
-    llm = _read_cfg_llm(cfg.raw)
-    return str(llm.get("model") or "qwen2.5-coder-0.5b-instruct")
+    try:
+        return str(cfg.llm.model or "")
+    except Exception:
+        llm = _read_cfg_llm(cfg.raw)
+        return str(llm.get("model") or "")
 
 
 def _effective_provider(cfg: TermiteConfig) -> str:
-    llm = _read_cfg_llm(cfg.raw)
-    return str(llm.get("provider") or "endpoint_only")
+    try:
+        return str(cfg.llm.provider or "endpoint_only")
+    except Exception:
+        llm = _read_cfg_llm(cfg.raw)
+        return str(llm.get("provider") or "endpoint_only")
 
 
 def _ping_path(cfg: TermiteConfig) -> str:
-    llm = _read_cfg_llm(cfg.raw)
-    ping = llm.get("ping") or {}
-    return str(ping.get("path") or "/v1/models")
+    # Laptop-mode standard: OpenAI-compatible readiness endpoint.
+    # Allow override via config for edge cases.
+    try:
+        p = str(cfg.llm.ping_path or "/v1/models")
+        return p
+    except Exception:
+        llm = _read_cfg_llm(cfg.raw)
+        ping = llm.get("ping") or {}
+        return str(ping.get("path") or "/v1/models")
 
 
 def _ping_timeout(cfg: TermiteConfig) -> float:
-    llm = _read_cfg_llm(cfg.raw)
-    ping = llm.get("ping") or {}
-    return float(ping.get("timeout_s") or 3.0)
+    try:
+        return float(cfg.llm.ping_timeout_s)
+    except Exception:
+        llm = _read_cfg_llm(cfg.raw)
+        ping = llm.get("ping") or {}
+        return float(ping.get("timeout_s") or 3.0)
 
 
 def _launch_cfg(cfg: TermiteConfig) -> Dict[str, Any]:
+    # Prefer structured config; keep legacy raw.
     llm = _read_cfg_llm(cfg.raw)
     return (llm.get("launch") or {})
 
 
 def _startup_timeout(cfg: TermiteConfig) -> float:
-    lc = _launch_cfg(cfg)
-    return float(lc.get("startup_timeout_s") or 30.0)
+    try:
+        return float(cfg.llm.launch.startup_timeout_seconds)
+    except Exception:
+        lc = _launch_cfg(cfg)
+        return float(lc.get("startup_timeout_seconds") or lc.get("startup_timeout_s") or 30.0)
 
 
 def _stop_timeout(cfg: TermiteConfig) -> float:
-    lc = _launch_cfg(cfg)
-    return float(lc.get("stop_timeout_s") or 10.0)
+    try:
+        return float(cfg.llm.launch.kill_timeout_seconds)
+    except Exception:
+        lc = _launch_cfg(cfg)
+        return float(lc.get("kill_timeout_seconds") or lc.get("stop_timeout_s") or 10.0)
 
 
 def _compute_endpoint_id(toolchain_id: str, base_url: str, model: str, started_utc: str | None) -> str:
@@ -110,6 +146,103 @@ def _proc_running(pid: int) -> bool:
         return False
 
 
+def _atomic_write_json(path: Path, obj: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _build_launch_cmd(cfg: TermiteConfig) -> List[str]:
+    """Return argv list for launching an OpenAI-compatible server.
+
+    Accepts either a list of strings or a shell-ish string.
+    If no command is provided and provider is known, builds a template.
+    """
+    provider = _effective_provider(cfg)
+    llm_cfg = cfg.llm
+    cmd_raw: Union[str, List[str], None]
+    try:
+        cmd_raw = llm_cfg.launch.command
+    except Exception:
+        cmd_raw = None
+
+    # Template command if not provided.
+    if (cmd_raw is None or cmd_raw == "" or cmd_raw == []):
+        host = getattr(llm_cfg, "host", "127.0.0.1")
+        port = int(getattr(llm_cfg, "port", 8789))
+        model = _effective_model(cfg)
+        model_path = (getattr(llm_cfg, "model_path", None) or "").strip()
+
+        if provider == "llama_cpp_server":
+            # llama.cpp's OpenAI-compatible server binary is typically `llama-server`.
+            # Users may override this in config.
+            if not model_path:
+                model_path = model
+            return [
+                "llama-server",
+                "-m",
+                model_path,
+                "--host",
+                host,
+                "--port",
+                str(port),
+            ]
+
+        if provider == "vllm":
+            # vLLM OpenAI-compatible API server
+            model_arg = model_path if model_path else model
+            return [
+                "python",
+                "-m",
+                "vllm.entrypoints.openai.api_server",
+                "--host",
+                host,
+                "--port",
+                str(port),
+                "--model",
+                model_arg,
+            ]
+
+        raise RuntimeError(
+            "llm.launch.command is required (or set llm.provider to llama_cpp_server/vllm to enable templates)"
+        )
+
+    if isinstance(cmd_raw, list):
+        if not all(isinstance(x, str) for x in cmd_raw):
+            raise RuntimeError("llm.launch.command list must contain only strings")
+        return list(cmd_raw)
+
+    if isinstance(cmd_raw, str):
+        # Best-effort split. Prefer list-form on Windows.
+        return shlex.split(cmd_raw, posix=(os.name != "nt"))
+
+    raise RuntimeError("llm.launch.command must be a string or a list")
+
+
+def _spawn_process(cfg: TermiteConfig, argv: List[str], *, cwd: Path, env: Dict[str, str]) -> subprocess.Popen:
+    logf = _log_path(cfg)
+    logf.parent.mkdir(parents=True, exist_ok=True)
+
+    popen_kwargs: Dict[str, Any] = {
+        "cwd": str(cwd),
+        "env": env,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
+        "text": False,
+    }
+    if os.name == "nt":
+        popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    # Stream stdout/stderr to a single log file.
+    out = logf.open("ab")
+    popen_kwargs["stdout"] = out
+    p = subprocess.Popen(argv, **popen_kwargs)
+    return p
+
+
 def read_status(cfg: TermiteConfig) -> LLMRuntimeStatus:
     sp = _state_path(cfg)
     base_url = _effective_base_url(cfg)
@@ -119,6 +252,7 @@ def read_status(cfg: TermiteConfig) -> LLMRuntimeStatus:
     managed = False
     started_utc = None
     running = False
+    last_error: Optional[str] = None
 
     if sp.exists():
         try:
@@ -128,8 +262,9 @@ def read_status(cfg: TermiteConfig) -> LLMRuntimeStatus:
             provider = str(st.get("provider") or provider)
             pid = int(st["pid"]) if st.get("pid") is not None else None
             managed = bool(st.get("managed", False))
-            started_utc = str(st.get("started_utc")) if st.get("started_utc") else None
+            started_utc = str(st.get("started_at") or st.get("started_utc")) if (st.get("started_at") or st.get("started_utc")) else None
             running = bool(st.get("running", False))
+            last_error = str(st.get("last_error")) if st.get("last_error") else None
         except Exception:
             # fall back to config-only view
             pass
@@ -166,23 +301,47 @@ def ping(cfg: TermiteConfig) -> Tuple[bool, str]:
         return False, f"FAIL {url} :: {e}"
 
 
-def _write_state(cfg: TermiteConfig, *, pid: Optional[int], managed: bool, running: bool, started_utc: Optional[str]) -> None:
+def _write_state(
+    cfg: TermiteConfig,
+    *,
+    pid: Optional[int],
+    managed: bool,
+    running: bool,
+    started_at: Optional[str],
+    launch_cmd: Optional[List[str]] = None,
+    last_error: Optional[str] = None,
+) -> None:
     d = _llm_dir(cfg)
     d.mkdir(parents=True, exist_ok=True)
+
+    base_url = _effective_base_url(cfg)
+    model = _effective_model(cfg)
+    provider = _effective_provider(cfg)
+    endpoint_id = _compute_endpoint_id(cfg.toolchain_id, base_url, model, started_at)
+
     st = {
         "toolchain_id": cfg.toolchain_id,
-        "provider": _effective_provider(cfg),
-        "base_url": _effective_base_url(cfg),
-        "model": _effective_model(cfg),
+        "provider": provider,
+        "base_url": base_url,
+        "model": model,
         "pid": pid,
         "managed": bool(managed),
         "running": bool(running),
-        "started_utc": started_utc,
-        "state_version": "1.0",
+        "started_at": started_at,
+        "endpoint_id": endpoint_id,
+        "state_version": "2.0",
     }
-    (_state_path(cfg)).write_text(json.dumps(st, indent=2, sort_keys=True), encoding="utf-8")
+    if launch_cmd is not None:
+        st["launch_cmd"] = list(launch_cmd)
+    if last_error:
+        st["last_error"] = str(last_error)
+
+    _atomic_write_json(_state_path(cfg), st)
     if pid is not None:
-        _pid_path(cfg).write_text(str(pid), encoding="utf-8")
+        try:
+            _pid_path(cfg).write_text(str(pid), encoding="utf-8")
+        except Exception:
+            pass
 
 
 def start(cfg: TermiteConfig, *, force: bool = False) -> LLMRuntimeStatus:
@@ -202,51 +361,70 @@ def start(cfg: TermiteConfig, *, force: bool = False) -> LLMRuntimeStatus:
     logf = _log_path(cfg)
     logf.parent.mkdir(parents=True, exist_ok=True)
 
-    lc = _launch_cfg(cfg)
-    cmd = lc.get("command")
-    enabled = bool(lc.get("enabled", False))
-    cwd = lc.get("cwd")
-    env = lc.get("env") or {}
-
-    started_utc = utc_now_iso()
+    llm_cfg = cfg.llm
+    enabled = bool(getattr(llm_cfg.launch, "enabled", False))
+    started_at = utc_now_iso()
 
     pid: Optional[int] = None
     managed = False
 
-    if enabled and cmd:
-        if not isinstance(cmd, list) or not all(isinstance(x, str) for x in cmd):
-            raise RuntimeError("llm.launch.command must be a YAML list of strings")
+    model = _effective_model(cfg).strip()
+    if enabled and not model:
+        raise RuntimeError("llm.model is required when llm.launch.enabled=true")
+
+    model_path = (getattr(llm_cfg, "model_path", None) or "").strip()
+    if enabled and model_path:
+        mp = Path(model_path)
+        if not mp.exists():
+            raise RuntimeError(f"llm.model_path does not exist: {mp} (download weights or update config)")
+
+    launch_cmd: Optional[List[str]] = None
+
+    if enabled:
         managed = True
+        launch_cmd = _build_launch_cmd(cfg)
+
         # merge env
         proc_env = dict(os.environ)
-        for k, v in env.items():
+        for k, v in dict(getattr(llm_cfg.launch, "env", {}) or {}).items():
             proc_env[str(k)] = str(v)
-        # note: stdout/stderr to a single log file
-        with logf.open("ab") as out:
-            p = subprocess.Popen(
-                cmd,
-                cwd=str((cfg.runtime_root / str(cwd)).resolve()) if cwd else str(d),
-                env=proc_env,
-                stdout=out,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,  # so Termux can detach reliably
-            )
+
+        # cwd: allow relative to runtime_root
+        cwd_raw = getattr(llm_cfg.launch, "cwd", None)
+        if cwd_raw:
+            cwd_path = (cfg.runtime_root / str(cwd_raw)).resolve()
+        else:
+            cwd_path = d
+
+        p = _spawn_process(cfg, launch_cmd, cwd=cwd_path, env=proc_env)
         pid = int(p.pid)
-        _write_state(cfg, pid=pid, managed=True, running=True, started_utc=started_utc)
+        _write_state(cfg, pid=pid, managed=True, running=True, started_at=started_at, launch_cmd=launch_cmd)
     else:
         # endpoint-only: do not spawn, but record the endpoint as "active" if it responds
         ok, _msg = ping(cfg)
         if not ok:
             raise RuntimeError("Endpoint-only mode: ping failed; refuse to mark active (configure llm.launch or start server manually)")
-        _write_state(cfg, pid=None, managed=False, running=True, started_utc=started_utc)
+        _write_state(cfg, pid=None, managed=False, running=True, started_at=started_at)
 
     # wait for readiness (ping)
     deadline = time.time() + _startup_timeout(cfg)
+    last_err = ""
     while time.time() < deadline:
         ok, _ = ping(cfg)
         if ok:
             break
         time.sleep(0.6)
+
+    ok, msg = ping(cfg)
+    if not ok:
+        last_err = msg
+        # ensure we do not leave a stale pid/state behind
+        try:
+            stop(cfg, force_kill=True)
+        except Exception:
+            pass
+        _write_state(cfg, pid=None, managed=False, running=False, started_at=started_at, launch_cmd=launch_cmd, last_error=last_err)
+        raise RuntimeError(f"llm_start_failed: {last_err}")
 
     # write provenance (best-effort; requires termite init)
     try:
@@ -258,7 +436,8 @@ def start(cfg: TermiteConfig, *, force: bool = False) -> LLMRuntimeStatus:
             "provider": _effective_provider(cfg),
             "managed": managed,
             "pid": pid,
-            "started_utc": started_utc,
+            "started_at": started_at,
+            "launch_cmd": launch_cmd,
         })
         con.close()
     except Exception:
@@ -273,8 +452,13 @@ def stop(cfg: TermiteConfig, *, force_kill: bool = False) -> LLMRuntimeStatus:
     stopped_utc = utc_now_iso()
 
     if pid is not None and st.managed and _proc_running(pid):
+        # Try graceful termination first.
         try:
-            os.kill(pid, signal.SIGTERM)
+            if os.name == "nt":
+                # Best-effort: SIGTERM may map to TerminateProcess; still try.
+                os.kill(pid, signal.SIGTERM)
+            else:
+                os.kill(pid, signal.SIGTERM)
         except Exception:
             pass
 
@@ -282,14 +466,26 @@ def stop(cfg: TermiteConfig, *, force_kill: bool = False) -> LLMRuntimeStatus:
         while time.time() < deadline and _proc_running(pid):
             time.sleep(0.2)
 
-        if _proc_running(pid) and force_kill:
-            try:
-                os.kill(pid, signal.SIGKILL)
-            except Exception:
-                pass
+        if _proc_running(pid):
+            if os.name == "nt":
+                # Fallback: ensure the process tree is terminated.
+                try:
+                    subprocess.run(
+                        ["taskkill", "/PID", str(pid), "/T", "/F"],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        check=False,
+                    )
+                except Exception:
+                    pass
+            elif force_kill:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except Exception:
+                    pass
 
     # mark inactive
-    _write_state(cfg, pid=None, managed=False, running=False, started_utc=st.started_utc or stopped_utc)
+    _write_state(cfg, pid=None, managed=False, running=False, started_at=st.started_utc or stopped_utc)
     try:
         _pid_path(cfg).unlink(missing_ok=True)  # type: ignore[arg-type]
     except Exception:
@@ -313,4 +509,129 @@ def stop(cfg: TermiteConfig, *, force_kill: bool = False) -> LLMRuntimeStatus:
         pass
 
     return read_status(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Laptop-mode friendly APIs (requested names)
+# ---------------------------------------------------------------------------
+
+
+def start_llm(cfg: TermiteConfig, *, force: bool = False) -> Dict[str, Any]:
+    st = start(cfg, force=force)
+    return status_llm(cfg)
+
+
+def stop_llm(cfg: TermiteConfig, *, force_kill: bool = False) -> Dict[str, Any]:
+    stop(cfg, force_kill=force_kill)
+    return status_llm(cfg)
+
+
+def ping_llm(cfg: TermiteConfig) -> Dict[str, Any]:
+    ok, msg = ping(cfg)
+    return {"ok": bool(ok), "msg": msg}
+
+
+def status_llm(cfg: TermiteConfig) -> Dict[str, Any]:
+    sp = _state_path(cfg)
+    base_url = _effective_base_url(cfg)
+    model = _effective_model(cfg)
+    provider = _effective_provider(cfg)
+    launch_enabled = bool(getattr(cfg.llm.launch, "enabled", False))
+
+    pid: Optional[int] = None
+    managed = False
+    started_at: Optional[str] = None
+    endpoint_id: Optional[str] = None
+    last_error: Optional[str] = None
+    launch_cmd: Optional[List[str]] = None
+
+    if sp.exists():
+        try:
+            st = json.loads(sp.read_text(encoding="utf-8"))
+            base_url = str(st.get("base_url") or base_url)
+            model = str(st.get("model") or model)
+            provider = str(st.get("provider") or provider)
+            pid = int(st["pid"]) if st.get("pid") is not None else None
+            managed = bool(st.get("managed", False))
+            started_at = str(st.get("started_at") or st.get("started_utc")) if (st.get("started_at") or st.get("started_utc")) else None
+            endpoint_id = str(st.get("endpoint_id")) if st.get("endpoint_id") else None
+            last_error = str(st.get("last_error")) if st.get("last_error") else None
+            if isinstance(st.get("launch_cmd"), list) and all(isinstance(x, str) for x in st.get("launch_cmd")):
+                launch_cmd = list(st.get("launch_cmd"))
+        except Exception:
+            pass
+
+    if endpoint_id is None:
+        endpoint_id = _compute_endpoint_id(cfg.toolchain_id, base_url, model, started_at)
+
+    stale_pid = False
+    alive = True
+    if pid is not None:
+        alive = _proc_running(pid)
+
+    ready = False
+    ping_msg = ""
+    if alive:
+        ok, ping_msg = ping(cfg)
+        ready = bool(ok)
+        if not ready and not last_error:
+            last_error = ping_msg
+
+    # Spec: if PID exists but process is dead OR ping fails => stale_pid=true.
+    if pid is not None and (not alive or not ready):
+        stale_pid = True
+
+    running = bool(alive and ready)
+
+    # If we had a pid but it is dead or server is unready, ensure state doesn't claim running.
+    if sp.exists():
+        try:
+            current = json.loads(sp.read_text(encoding="utf-8"))
+            if bool(current.get("running", False)) and not running:
+                current["running"] = False
+                # Keep PID as recorded so stale_pid remains diagnosable.
+                # Only an explicit stop should clear the PID and pid file.
+                if current.get("pid") is None:
+                    current["pid"] = pid
+                if last_error:
+                    current["last_error"] = last_error
+                _atomic_write_json(sp, current)
+        except Exception:
+            pass
+
+    return {
+        "running": running,
+        "ready": ready,
+        "stale_pid": stale_pid,
+        "launch_enabled": launch_enabled,
+        "provider": provider,
+        "base_url": base_url,
+        "model": model,
+        "endpoint_id": endpoint_id,
+        "toolchain_id": cfg.toolchain_id,
+        "started_at": started_at,
+        "pid": pid if alive else None,
+        "managed": bool(managed),
+        "launch_cmd": launch_cmd,
+        "last_error": last_error,
+        "state_path": str(sp),
+        "ping_msg": ping_msg,
+    }
+
+
+def resolve_active_endpoint(cfg: TermiteConfig) -> Optional[Dict[str, Any]]:
+    """Return active endpoint info if the runtime is running and ready."""
+    st = status_llm(cfg)
+    if st.get("running"):
+        return {
+            "base_url": str(st.get("base_url") or ""),
+            "model": str(st.get("model") or ""),
+            "endpoint_id": str(st.get("endpoint_id") or ""),
+            "toolchain_id": str(st.get("toolchain_id") or ""),
+            "provider": str(st.get("provider") or ""),
+            "started_at": st.get("started_at"),
+            "pid": st.get("pid"),
+        }
+    return None
+
 

--- a/termite_fieldpack/tests/__init__.py
+++ b/termite_fieldpack/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test helpers for termite-fieldpack (repo-local)."""

--- a/termite_fieldpack/tests/support/__init__.py
+++ b/termite_fieldpack/tests/support/__init__.py
@@ -1,0 +1,1 @@
+"""Support modules for termite-fieldpack tests."""

--- a/termite_fieldpack/tests/support/fake_openai_server.py
+++ b/termite_fieldpack/tests/support/fake_openai_server.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def _json_bytes(obj) -> bytes:
+    return json.dumps(obj, sort_keys=True).encode("utf-8")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "FakeOpenAI/0.1"
+
+    def _send(self, status: int, obj) -> None:
+        body = _json_bytes(obj)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path.rstrip("/") == "/v1/models":
+            model_id = getattr(self.server, "model_id", "fake-model")
+            return self._send(
+                200,
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": model_id,
+                            "object": "model",
+                            "owned_by": "fake",
+                        }
+                    ],
+                },
+            )
+        return self._send(404, {"error": {"message": "not_found", "path": self.path}})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path.rstrip("/") == "/v1/chat/completions":
+            try:
+                n = int(self.headers.get("Content-Length", "0") or "0")
+            except Exception:
+                n = 0
+            raw = self.rfile.read(n) if n > 0 else b""
+            try:
+                payload = json.loads(raw.decode("utf-8") or "{}")
+            except Exception:
+                payload = {}
+
+            model = str(payload.get("model") or getattr(self.server, "model_id", "fake-model"))
+            # Best-effort user prompt extraction.
+            user = ""
+            try:
+                msgs = payload.get("messages") or []
+                if msgs:
+                    user = str(msgs[-1].get("content") or "")
+            except Exception:
+                user = ""
+
+            content = f"fake-ok: {user}".strip()
+            return self._send(
+                200,
+                {
+                    "id": "chatcmpl-fake",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": content},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                },
+            )
+
+        return self._send(404, {"error": {"message": "not_found", "path": self.path}})
+
+    def log_message(self, fmt: str, *args) -> None:
+        # Keep tests quiet.
+        return
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Tiny fake OpenAI-compatible server for tests")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, required=True)
+    p.add_argument("--model", default="fake-model")
+    args = p.parse_args(argv)
+
+    httpd = ThreadingHTTPServer((args.host, int(args.port)), _Handler)
+    httpd.model_id = str(args.model)
+
+    try:
+        httpd.serve_forever(poll_interval=0.25)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        try:
+            httpd.server_close()
+        except Exception:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/termite_fieldpack/tests/test_llm_runtime_laptop.py
+++ b/termite_fieldpack/tests/test_llm_runtime_laptop.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from termite.config import TermiteConfig
+from termite.llm_runtime import ping_llm, start_llm, status_llm, stop_llm
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        s.listen(1)
+        return int(s.getsockname()[1])
+
+
+def _mk_cfg(tmp_path: Path, port: int) -> TermiteConfig:
+    runtime_root = tmp_path / "runtime"
+    raw = {
+        "termite": {
+            "runtime_root": str(runtime_root),
+            "cas_root": str(runtime_root / "cas"),
+            "db_path": str(runtime_root / "termite.sqlite"),
+            "bundles_out": str(tmp_path / "bundles_out"),
+            "offline_mode": True,
+            "network_policy": "deny_by_default",
+        },
+        "toolchain": {"toolchain_id": "TEST_TOOLCHAIN"},
+        "llm": {
+            "provider": "endpoint_only",
+            "host": "127.0.0.1",
+            "port": int(port),
+            "model": "fake-model",
+            "offline_loopback_only": True,
+            "ping": {"path": "/v1/models", "timeout_s": 2},
+            "launch": {
+                "enabled": True,
+                "command": [
+                    sys.executable,
+                    "-m",
+                    "termite_fieldpack.tests.support.fake_openai_server",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(port),
+                    "--model",
+                    "fake-model",
+                ],
+                "env": {},
+                "cwd": None,
+                "startup_timeout_seconds": 10,
+                "kill_timeout_seconds": 5,
+            },
+        },
+    }
+    return TermiteConfig(raw)
+
+
+def test_llm_runtime_start_ping_stop_status(tmp_path: Path) -> None:
+    port = _free_port()
+    cfg = _mk_cfg(tmp_path, port)
+
+    st = start_llm(cfg)
+    assert st["running"] is True
+    assert st.get("ready") is True
+    assert st.get("stale_pid") is False
+    assert st.get("base_url", "").endswith(f":{port}")
+    assert st.get("model") == "fake-model"
+    assert st.get("endpoint_id")
+
+    ping = ping_llm(cfg)
+    assert ping["ok"] is True
+
+    stopped = stop_llm(cfg, force_kill=False)
+    assert stopped["running"] is False
+
+    # Active endpoint file should contain the required keys.
+    state_path = Path(stopped["state_path"])
+    obj = json.loads(state_path.read_text(encoding="utf-8"))
+    for k in ["running", "base_url", "model", "endpoint_id", "toolchain_id", "started_at", "provider", "pid"]:
+        assert k in obj
+
+
+def test_llm_runtime_status_stale_pid_when_process_dies(tmp_path: Path) -> None:
+    port = _free_port()
+    cfg = _mk_cfg(tmp_path, port)
+
+    st = start_llm(cfg)
+    pid = int(st["pid"])
+
+    # Kill the child process externally.
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    else:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except Exception:
+            pass
+
+    # Give it a moment to exit and for /v1/models to fail.
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        s2 = status_llm(cfg)
+        if s2.get("stale_pid") or not s2.get("running"):
+            break
+        time.sleep(0.1)
+
+    s2 = status_llm(cfg)
+    assert s2.get("running") is False
+    assert s2.get("stale_pid") is True
+
+    # Cleanup is idempotent.
+    stop_llm(cfg, force_kill=True)


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Add laptop-mode LLM runtime management with UI controls and structured configuration, plus worker liveness monitoring and more deterministic deployment.

New Features:
- Introduce structured LLM configuration and laptop-mode runtime management APIs for starting, stopping, pinging, and resolving active OpenAI-compatible endpoints.
- Expose Termite LLM lifecycle commands through new Fieldgrade UI HTTP endpoints and an LLM control panel in the web UI.
- Add a worker liveness heartbeat mechanism with an API endpoint and Docker healthcheck for monitoring the background worker process.

Enhancements:
- Refine LLM runtime state persistence to include endpoint identity, launch command, and last error with atomic JSON writes and improved PID handling across platforms.
- Prefer structured LLM config accessors in Termite while keeping backward compatibility with legacy raw configuration keys.
- Improve Fieldgrade UI API JSON handling with pluggable hooks for auth error reporting and add protocol typing for registry loader results.
- Normalize YAML indentation for registry component and variant catalogs for readability.

Deployment:
- Tighten VPS deployment workflow by resolving the deploy ref to an exact commit SHA, enforcing a clean working tree, and checking out in detached HEAD mode before composing services.

Documentation:
- Document the laptop-mode LLM runtime workflow and configuration in a new LLM runtime guide.

Tests:
- Add unit tests for the laptop-mode LLM runtime lifecycle using a fake OpenAI-compatible server.
- Add tests for the worker status API endpoint shape in the Fieldgrade UI backend.