### PR TITLE
PR-01: Canonical GraphDelta Ledger + Stable IDs

### DIFF
--- a/docs/mgo/BASELINE.md
+++ b/docs/mgo/BASELINE.md
@@ -1,0 +1,25 @@
+# MGO v0.2 — Baseline (pre PR-01)
+
+Date: 2026-01-05
+
+Branch baseline: `main` @ `72d9732d35de58192a72c092d34c4dfe2afde303`
+Local working branch at time of run: `mgo/pr-01-canonical-graphdelta-ledger`
+
+## Tests
+
+Command:
+
+- `C:/Users/georg/Fieldgrade/.venv/Scripts/python.exe -m pytest -q --rootdir C:\Users\georg\Fieldgrade\FIELDGRADE_FULLSTACK_WINDOWS_LAPTOP_STRICT_DSSE_CDX\fg_next`
+
+Result:
+
+- PASS (all tests)
+
+## Notes
+
+- The mission references two external source-of-truth inputs:
+  - `/mnt/data/README (7).md`
+  - `/mnt/data/KG Observability and Actuation Protocols.pdf`
+
+Those files are not present in this working tree. PR-01 proceeds using the requirements listed in the mission prompt.
+If you want strict conformance to the PDF, please attach it into the repo (or provide the text) so we can mechanically cross-check.

--- a/docs/mgo/IMPLEMENTATION_MAP.md
+++ b/docs/mgo/IMPLEMENTATION_MAP.md
@@ -1,0 +1,94 @@
+# MGO v0.2 — Implementation Map
+
+This doc is a living map of where MGO touches the repo, organized by PR phase.
+
+## Current architecture anchors
+
+- `termite_fieldpack/`: untrusted inputs → verified sealed bundles (includes `kg_delta.jsonl`)
+- `mite_ecology/`: design-time KG + deterministic analytics, with an existing `kg_deltas` hash-chain (SQLite)
+- `fieldgrade_ui/`: operator UX + lightweight graph explorer
+
+## PR-01 — Canonical GraphDelta Ledger + Stable IDs
+
+**Goal**
+
+- Introduce an append-only, hash-chained `GraphDelta` ledger as the canonical representation of KG mutations.
+- Provide canonical JSON serialization and stable URN helpers.
+- Provide deterministic replay from ledger → KG serialization.
+
+**Planned changes (additive, minimal risk)**
+
+- New schema:
+  - `schemas/graph_delta_event_v1.json`
+- Schema registry update (if required by repo conventions):
+  - `schemas/ldna_registry.yaml` (add a `ldna://json/graph_delta_event@1.0.0` entry)
+- New module (proposed):
+  - `mite_ecology/mite_ecology/graph_delta.py` (canonical JSON + event hashing + append/verify)
+- KG mutation hook (minimal touch):
+  - `mite_ecology/mite_ecology/kg.py` (ensure mutations go through a single emission point)
+- Replay utility:
+  - `scripts/ledger_replay.py` (verify chain + apply events deterministically + emit canonical KG JSON)
+- Tests:
+  - `mite_ecology/tests/test_graph_delta_ledger.py`
+
+**Compatibility notes**
+
+- Do not change existing CLI entrypoints.
+- Do not change existing on-disk formats inside sealed bundles.
+- Keep the existing `kg_deltas` SQLite chain intact; PR-01 can initially dual-write (SQLite + ledger file) to avoid breaking workflows.
+
+**Risks**
+
+- Performance: one event per op can be large. Mitigation: keep payload minimal, stable ordering, and allow chunked replay.
+- Semantics: existing KG ops include domain-specific op names (e.g., `ADD_NODE`). PR-01 should encode them without renaming.
+
+## PR-02 — RunContext Everywhere
+
+Primary touchpoints:
+
+- Termite seal/ingest outputs: run context artifact emission
+- Ecology import + delta emission: attach run_id/trace_id everywhere
+- UI APIs: runs + deltas listing endpoints
+
+## PR-03 — PROV overlay + cycle detection
+
+Primary touchpoints:
+
+- Add Prov nodes/edges (Entity/Activity/Agent)
+- Add API `GET /api/prov/path`
+
+## PR-04 — ArchitectureSpec + structural diff
+
+Primary touchpoints:
+
+- Add ArchitectureSpec nodes
+- Deterministic diff artifact generation + UI viewer
+
+## PR-05 — Doc coverage + staleness
+
+Primary touchpoints:
+
+- Doc nodes + staleness evaluation from hashes
+- UI quality lens
+
+## PR-06 — Metrics + quality gates bound to runs
+
+Primary touchpoints:
+
+- Metric/GateResult nodes
+- Promotion gating alignment with existing review modes
+
+## PR-07 — Attestations + SBOM/AIBOM linkage
+
+Primary touchpoints:
+
+- Attestation nodes
+- BOM generation at seal time + UI badge
+
+## PR-08 — Lifecycle controller + actuation boundary
+
+Primary touchpoints:
+
+- Actuation artifacts (WillCommit, AbyssCertificate)
+- API plan/certify/execute + UI panel
+- Hard gate effectful ops

--- a/mite_ecology/mite_ecology/bundle_accept.py
+++ b/mite_ecology/mite_ecology/bundle_accept.py
@@ -357,6 +357,26 @@ def accept_termite_bundle(
                     ingest_kind="MERGED",
                     notes=notes,
                 )
+            from .graph_delta import append_graph_delta_event, default_ledger_path_for_db
+            append_graph_delta_event(
+                default_ledger_path_for_db(db_path),
+                source="TERMITE",
+                ops_lines=delta_payload.splitlines(),
+                context_node_id=None,
+                run_id=None,
+                trace_id=None,
+                meta={
+                    "bundle_sha256": bundle_sha,
+                    "bundle_name": bundle_name,
+                    "delta_hash": delta_hash,
+                    "ingested_id": ing_id,
+                    "policy_id": policy_id,
+                    "policy_hash": policy_hash,
+                    "allowlist_hash": allowlist_hash,
+                    "toolchain_id": toolchain_id,
+                    "bundle_map_hash": bundle_map_hash,
+                },
+            )
             return {
                 "status": "MERGED",
                 "bundle_sha256": bundle_sha,

--- a/mite_ecology/mite_ecology/graph_delta.py
+++ b/mite_ecology/mite_ecology/graph_delta.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, Optional, Tuple
+
+from .hashutil import canonical_json, sha256_hex, sha256_str
+
+
+def urn_mite(kind: str, value: Any) -> str:
+    """Build a stable, content-addressed URN.
+
+    - For dict/list/etc: sha256(canonical_json(value))
+    - For str: sha256(value as utf-8)
+    - For bytes: sha256(bytes)
+
+    Output: urn:mite:<kind>:<sha256>
+    """
+    k = str(kind).strip().lower()
+    if not k:
+        raise ValueError("kind must be non-empty")
+
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        h = sha256_hex(bytes(value))
+    elif isinstance(value, str):
+        h = sha256_str(value)
+    else:
+        h = sha256_str(canonical_json(value))
+
+    return f"urn:mite:{k}:{h}"
+
+
+def default_ledger_path_for_db(db_path: Path) -> Path:
+    return db_path.resolve().parent / "graph_delta_ledger.jsonl"
+
+
+def _canonical_jsonl(lines: Iterable[str]) -> str:
+    out = []
+    for ln in lines:
+        s = ln.strip()
+        if not s:
+            continue
+        # Ensure each line is canonical JSON.
+        out.append(canonical_json(json.loads(s)))
+    return "\n".join(out) + ("\n" if out else "")
+
+
+def _read_last_nonempty_line(path: Path) -> Optional[str]:
+    if not path.exists():
+        return None
+    data = path.read_bytes()
+    if not data:
+        return None
+    lines = data.decode("utf-8").splitlines()
+    for ln in reversed(lines):
+        if ln.strip():
+            return ln
+    return None
+
+
+def latest_event_hash(path: Path) -> Optional[str]:
+    ln = _read_last_nonempty_line(path)
+    if not ln:
+        return None
+    obj = json.loads(ln)
+    h = obj.get("event_hash")
+    return str(h) if h else None
+
+
+def _hash_event(prev_hash: Optional[str], event_body: Dict[str, Any]) -> str:
+    # Hash is over prev_hash + canonical_json(event_body) to keep it deterministic.
+    return sha256_str((prev_hash or "") + "|" + canonical_json(event_body))
+
+
+@dataclass(frozen=True)
+class AppendResult:
+    prev_hash: Optional[str]
+    event_hash: str
+
+
+def append_graph_delta_event(
+    ledger_path: Path,
+    *,
+    source: str,
+    ops_lines: Iterable[str],
+    context_node_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    meta: Optional[Dict[str, Any]] = None,
+) -> AppendResult:
+    """Append one GraphDelta ledger event.
+
+    This is intended to be called exactly once per *applied* KG mutation batch.
+    """
+    ledger_path = Path(ledger_path)
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+
+    ops_payload = _canonical_jsonl(ops_lines)
+    ops_hash = sha256_str(ops_payload)
+
+    prev = latest_event_hash(ledger_path)
+    body = {
+        "v": 1,
+        "kind": "graph_delta",
+        "prev_hash": prev,
+        "payload": {
+            "source": str(source),
+            "context_node_id": (str(context_node_id) if context_node_id is not None else None),
+            "run_id": (str(run_id) if run_id is not None else None),
+            "trace_id": (str(trace_id) if trace_id is not None else None),
+            "ops_kind": "kg_delta.jsonl",
+            "ops_payload": ops_payload,
+            "ops_hash": ops_hash,
+            "meta": meta or None,
+        },
+    }
+
+    ev_hash = _hash_event(prev, body)
+    record = dict(body)
+    record["event_hash"] = ev_hash
+
+    with ledger_path.open("a", encoding="utf-8", newline="\n") as f:
+        f.write(canonical_json(record) + "\n")
+
+    return AppendResult(prev_hash=prev, event_hash=ev_hash)
+
+
+def iter_ledger(ledger_path: Path) -> Iterator[Dict[str, Any]]:
+    p = Path(ledger_path)
+    if not p.exists():
+        return
+    for ln in p.read_text(encoding="utf-8").splitlines():
+        if not ln.strip():
+            continue
+        yield json.loads(ln)
+
+
+def verify_ledger_chain(ledger_path: Path) -> Tuple[bool, int]:
+    """Verify hash-chain integrity. Returns (ok, events_count)."""
+    prev: Optional[str] = None
+    n = 0
+    for rec in iter_ledger(ledger_path):
+        n += 1
+        if rec.get("v") != 1 or rec.get("kind") != "graph_delta":
+            return False, n
+        if (rec.get("prev_hash") or None) != prev:
+            return False, n
+
+        ev_hash = rec.get("event_hash")
+        body = dict(rec)
+        body.pop("event_hash", None)
+
+        expect = _hash_event(prev, body)
+        if str(ev_hash) != expect:
+            return False, n
+        prev = str(ev_hash)
+
+    return True, n
+
+
+def ops_from_event(rec: Dict[str, Any]) -> str:
+    payload = rec.get("payload") or {}
+    return str(payload.get("ops_payload") or "")

--- a/mite_ecology/tests/test_graph_delta_ledger.py
+++ b/mite_ecology/tests/test_graph_delta_ledger.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from mite_ecology.db import init_db
+from mite_ecology.delta import apply_delta_lines
+from mite_ecology.graph_delta import (
+    append_graph_delta_event,
+    iter_ledger,
+    ops_from_event,
+    urn_mite,
+    verify_ledger_chain,
+)
+from mite_ecology.kg import KnowledgeGraph
+from mite_ecology.replay import snapshot_hash
+
+
+def _schema_path() -> Path:
+    return (Path(__file__).resolve().parents[1] / "sql" / "schema.sql").resolve()
+
+
+def test_urn_mite_stable() -> None:
+    obj = {"a": 1, "b": [2, 3]}
+    u1 = urn_mite("artifact", obj)
+    u2 = urn_mite("artifact", {"b": [2, 3], "a": 1})
+    assert u1 == u2
+    assert u1.startswith("urn:mite:artifact:")
+
+
+def test_ledger_chain_ok(tmp_path: Path) -> None:
+    lp = tmp_path / "graph_delta_ledger.jsonl"
+
+    ops1 = [json.dumps({"op": "ADD_NODE", "id": "n1", "type": "Thing", "attrs": {"x": 1}})]
+    ops2 = [json.dumps({"op": "ADD_NODE", "id": "n2", "type": "Thing", "attrs": {"x": 2}})]
+
+    r1 = append_graph_delta_event(lp, source="TEST", ops_lines=ops1)
+    r2 = append_graph_delta_event(lp, source="TEST", ops_lines=ops2)
+
+    assert r1.event_hash != r2.event_hash
+
+    ok, n = verify_ledger_chain(lp)
+    assert ok is True
+    assert n == 2
+
+
+def test_replay_equivalence(tmp_path: Path) -> None:
+    schema = _schema_path()
+
+    # Build a ledger for two ops
+    lp = tmp_path / "graph_delta_ledger.jsonl"
+    ops = [
+        json.dumps({"op": "ADD_NODE", "id": "n1", "type": "Thing", "attrs": {"x": 1}}),
+        json.dumps({"op": "ADD_EDGE", "src": "n1", "dst": "n1", "type": "SELF", "attrs": {}}),
+    ]
+    append_graph_delta_event(lp, source="TEST", ops_lines=ops)
+
+    # Apply directly
+    con1 = sqlite3.connect(":memory:")
+    con1.row_factory = sqlite3.Row
+    init_db(con1, schema)
+    kg1 = KnowledgeGraph(con1)
+    apply_delta_lines(kg1, ops)
+    h1 = snapshot_hash(con1)
+
+    # Replay from ledger
+    con2 = sqlite3.connect(":memory:")
+    con2.row_factory = sqlite3.Row
+    init_db(con2, schema)
+    kg2 = KnowledgeGraph(con2)
+    for rec in iter_ledger(lp):
+        op_payload = ops_from_event(rec)
+        apply_delta_lines(kg2, op_payload.splitlines())
+    h2 = snapshot_hash(con2)
+
+    assert h1 == h2

--- a/schemas/graph_delta_event_v1.json
+++ b/schemas/graph_delta_event_v1.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "mite_ecology.schemas.graph_delta_event.v1",
+  "title": "GraphDelta Ledger Event (JSONL line)",
+  "type": "object",
+  "required": ["v", "kind", "prev_hash", "event_hash", "payload"],
+  "properties": {
+    "v": {"type": "integer", "const": 1},
+    "kind": {"type": "string", "const": "graph_delta"},
+    "prev_hash": {"type": ["string", "null"]},
+    "event_hash": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "required": ["ops_kind", "ops_payload", "ops_hash", "source"],
+      "properties": {
+        "source": {"type": "string"},
+        "context_node_id": {"type": ["string", "null"]},
+        "run_id": {"type": ["string", "null"]},
+        "trace_id": {"type": ["string", "null"]},
+        "ops_kind": {"type": "string", "const": "kg_delta.jsonl"},
+        "ops_payload": {"type": "string", "description": "Canonicalized JSONL of KG ops"},
+        "ops_hash": {"type": "string", "description": "sha256_hex(canonical_ops_payload)"},
+        "meta": {"type": ["object", "null"], "additionalProperties": true}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/ldna_registry.yaml
+++ b/schemas/ldna_registry.yaml
@@ -16,6 +16,10 @@ schemas:
   description: Neuroarch DSL fragment
   path: schemas/neuroarch_dsl.json
   sha256: 9cde04f8fb1d3626811795d16783b2307acf18da640f2e3be5e3d49a8ef62e37
+- uri: ldna://json/graph_delta_event@1.0.0
+  description: GraphDelta append-only ledger event (hash-chained)
+  path: schemas/graph_delta_event_v1.json
+  sha256: 08630866089a71926f5403ff5e9b1f89f9dedda4b1469d2bdbabb3b56b0be0b8
 - uri: ldna://yaml/registry_components@1.0.0
   description: Registry catalog (components)
   path: schemas/registry_components_v1.json

--- a/scripts/ledger_replay.py
+++ b/scripts/ledger_replay.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    # fg_next/scripts/ledger_replay.py -> fg_next
+    return Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    repo = _repo_root()
+    sys.path.insert(0, str(repo))
+
+    from mite_ecology.mite_ecology.db import init_db  # noqa: WPS433
+    from mite_ecology.mite_ecology.delta import apply_delta_lines  # noqa: WPS433
+    from mite_ecology.mite_ecology.graph_delta import iter_ledger, ops_from_event, verify_ledger_chain  # noqa: WPS433
+    from mite_ecology.mite_ecology.kg import KnowledgeGraph  # noqa: WPS433
+    from mite_ecology.mite_ecology.replay import snapshot_hash  # noqa: WPS433
+
+    ap = argparse.ArgumentParser(description="Replay a GraphDelta ledger into an empty KG and report snapshot hash.")
+    ap.add_argument("ledger", type=Path, help="Path to graph_delta_ledger.jsonl")
+    ap.add_argument("--schema", type=Path, default=None, help="Path to mite_ecology/sql/schema.sql")
+    ap.add_argument("--out", type=Path, default=None, help="Optional: write replay report JSON")
+    args = ap.parse_args()
+
+    ok, n = verify_ledger_chain(args.ledger)
+    if not ok:
+        rep = {"ok": False, "error": "ledger_chain_invalid", "events_seen": n}
+        if args.out:
+            args.out.write_text(json.dumps(rep, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        else:
+            print(json.dumps(rep, sort_keys=True))
+        return 2
+
+    schema_path = args.schema
+    if schema_path is None:
+        schema_path = (repo / "mite_ecology" / "sql" / "schema.sql").resolve()
+
+    mem = sqlite3.connect(":memory:")
+    mem.row_factory = sqlite3.Row
+    init_db(mem, schema_path)
+
+    kg = KnowledgeGraph(mem)
+    total_ops = 0
+    for rec in iter_ledger(args.ledger):
+        ops_payload = ops_from_event(rec)
+        lines = [ln for ln in ops_payload.splitlines() if ln.strip()]
+        total_ops += apply_delta_lines(kg, lines)
+
+    rep = {
+        "ok": True,
+        "events": n,
+        "ops_applied": total_ops,
+        "snapshot_hash": snapshot_hash(mem),
+    }
+
+    if args.out:
+        args.out.write_text(json.dumps(rep, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    else:
+        print(json.dumps(rep, sort_keys=True))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Introduce a hash-chained GraphDelta ledger as a canonical append-only record of knowledge graph mutations and wire it into existing mutation paths and tooling.

New Features:
- Add a GraphDelta ledger module providing canonical JSON serialization, stable URN generation, event hashing, and append/verify operations.
- Introduce configuration-driven resolution of a graph_delta_ledger.jsonl path and dual-write KG mutations to the new ledger alongside existing mechanisms when configured.
- Add a CLI script to replay a GraphDelta ledger into an empty knowledge graph and report a deterministic snapshot hash.

Enhancements:
- Hook LLM-driven KG mutation flows and Termite bundle ingestion to emit GraphDelta events with provenance metadata into the ledger.
- Register a new ldna schema for graph_delta_event records and document the MGO v0.2 plan and baseline state for the new GraphDelta-based architecture.

Documentation:
- Add MGO implementation map and baseline documentation describing the GraphDelta ledger introduction and related phases.

Tests:
- Add tests covering URN stability, ledger hash-chain integrity, and deterministic replay from ledger events back into a knowledge graph.