### PR TITLE
Sync local UI + GraphDelta updates

### DIFF
--- a/fieldgrade_ui/app.py
+++ b/fieldgrade_ui/app.py
@@ -13,6 +13,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Protocol, cast
 
+import uuid
 from fastapi import FastAPI, File, HTTPException, UploadFile, Request, Body
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -138,7 +139,7 @@ class CmdResult:
     parsed: Optional[Any] = None
 
 
-def _run_cmd(cmd: List[str], cwd: Path) -> CmdResult:
+def _run_cmd(cmd: List[str], cwd: Path, *, env: Optional[Dict[str, str]] = None) -> CmdResult:
     """Run a subprocess with stdout/stderr capture and a configurable timeout.
 
     Timeout is controlled by FG_CMD_TIMEOUT_S (default 600). Set to 0/empty to disable.
@@ -150,6 +151,7 @@ def _run_cmd(cmd: List[str], cwd: Path) -> CmdResult:
         p = subprocess.run(
             cmd,
             cwd=str(cwd),
+            env=env,
             capture_output=True,
             text=True,
             encoding="utf-8",
@@ -195,6 +197,99 @@ def _run_cmd(cmd: List[str], cwd: Path) -> CmdResult:
         stderr=stderr,
         parsed=parsed,
     )
+
+
+def _graph_delta_ledger_path() -> Path:
+    from mite_ecology.graph_delta import default_ledger_path_for_db
+
+    return default_ledger_path_for_db(_path_mite_db())
+
+
+@app.get("/api/runs")
+def api_runs(limit: int = 200) -> Dict[str, Any]:
+    """List known run_ids from the GraphDelta ledger."""
+
+    from mite_ecology.graph_delta import iter_ledger
+
+    ledger = _graph_delta_ledger_path()
+    if not ledger.exists():
+        return {"ok": True, "ledger_path": str(ledger), "runs": []}
+
+    agg: Dict[str, Dict[str, Any]] = {}
+    for rec in iter_ledger(ledger):
+        payload = rec.get("payload") or {}
+        run_id = str(payload.get("run_id") or "").strip()
+        trace_id = str(payload.get("trace_id") or "").strip()
+        source = str(payload.get("source") or "").strip() or "unknown"
+        if not run_id:
+            continue
+
+        r = agg.get(run_id)
+        if r is None:
+            r = {
+                "run_id": run_id,
+                "events": 0,
+                "sources": set(),
+                "trace_ids": set(),
+                "last_event_hash": None,
+            }
+            agg[run_id] = r
+        r["events"] += 1
+        r["sources"].add(source)
+        if trace_id:
+            r["trace_ids"].add(trace_id)
+        r["last_event_hash"] = rec.get("event_hash")
+
+    runs = list(agg.values())
+    # Sort by most recently seen event in file order (best-effort)
+    runs.sort(key=lambda x: str(x.get("last_event_hash") or ""), reverse=True)
+    if limit and limit > 0:
+        runs = runs[: int(limit)]
+
+    # JSON-ify sets
+    for r in runs:
+        r["sources"] = sorted(list(r["sources"]))
+        r["trace_ids"] = sorted(list(r["trace_ids"]))
+
+    return {"ok": True, "ledger_path": str(ledger), "runs": runs}
+
+
+@app.get("/api/deltas")
+def api_deltas(run_id: str | None = None, limit: int = 200) -> Dict[str, Any]:
+    """List GraphDelta events, optionally filtered by run_id."""
+
+    from mite_ecology.graph_delta import iter_ledger
+
+    ledger = _graph_delta_ledger_path()
+    if not ledger.exists():
+        return {"ok": True, "ledger_path": str(ledger), "events": []}
+
+    want = (run_id or "").strip() or None
+    events: list[Dict[str, Any]] = []
+    for rec in iter_ledger(ledger):
+        payload = rec.get("payload") or {}
+        rid = str(payload.get("run_id") or "").strip() or None
+        if want and rid != want:
+            continue
+        events.append(
+            {
+                "event_hash": rec.get("event_hash"),
+                "prev_hash": rec.get("prev_hash"),
+                "ops_hash": payload.get("ops_hash"),
+                "source": payload.get("source"),
+                "context_node_id": payload.get("context_node_id"),
+                "run_id": payload.get("run_id"),
+                "trace_id": payload.get("trace_id"),
+                "meta": payload.get("meta"),
+            }
+        )
+
+    # Return newest-first.
+    events.reverse()
+    if limit and limit > 0:
+        events = events[: int(limit)]
+
+    return {"ok": True, "ledger_path": str(ledger), "events": events}
 
 
 def _require_exists(p: Path, what: str) -> None:
@@ -774,13 +869,14 @@ def api_jobs_pipeline(request: Request, payload: dict):
     """
     upload_path = _sandbox_path(str(payload.get("upload_path") or ""), roots=[UPLOADS_DIR], what="upload_path", must_exist=True, must_be_file=True)
     label = str(payload.get("label", "run") or "run")
+    run_id = uuid.uuid4().hex
     job_id = create_job(
         jobs_db_path(),
         "pipeline",
-        {"upload_path": str(upload_path), "label": label},
+        {"upload_path": str(upload_path), "label": label, "run_id": run_id},
         owner_token_hash=_owner_hash(request) or "",
     )
-    return {"ok": True, "job_id": job_id, "upload_path": str(upload_path), "label": label}
+    return {"ok": True, "job_id": job_id, "upload_path": str(upload_path), "label": label, "run_id": run_id}
 
 if _MULTIPART_OK:
     @app.post("/api/pipeline/upload_run")
@@ -822,13 +918,14 @@ if _MULTIPART_OK:
                     raise HTTPException(status_code=413, detail=f"upload_too_large: {total} > {max_bytes}")
                 f.write(chunk)
 
+        run_id = uuid.uuid4().hex
         job_id = create_job(
             jobs_db_path(),
             "pipeline",
-            {"upload_path": str(dest), "label": label},
+            {"upload_path": str(dest), "label": label, "run_id": run_id},
             owner_token_hash=_owner_hash(request) or "",
         )
-        return {"ok": True, "job_id": job_id, "upload_path": str(dest), "bytes": total}
+        return {"ok": True, "job_id": job_id, "upload_path": str(dest), "bytes": total, "run_id": run_id}
 else:
     @app.post("/api/pipeline/upload_run")
     async def api_pipeline_upload_run_disabled() -> Dict[str, Any]:

--- a/fieldgrade_ui/app.py
+++ b/fieldgrade_ui/app.py
@@ -164,7 +164,7 @@ def _run_cmd(cmd: List[str], cwd: Path, *, env: Optional[Dict[str, str]] = None)
         raise HTTPException(status_code=400, detail="command_not_allowed")
 
     try:
-        p = subprocess.run(
+        p = subprocess.run(  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
             cmd,
             cwd=str(cwd),
             env=env,

--- a/fieldgrade_ui/static/index.html
+++ b/fieldgrade_ui/static/index.html
@@ -322,6 +322,25 @@
     <section class="panel" id="panel-graph">
       <h2>Graph Explorer</h2>
 
+      <div class="card">
+        <h3>GraphDelta ledger</h3>
+        <div class="row">
+          <label for="runSelect">Run</label>
+          <select id="runSelect" title="Filter ledger by run_id"></select>
+          <button type="button" id="btnRefreshRuns">Refresh</button>
+          <button type="button" id="btnLoadDeltas">Load deltas</button>
+        </div>
+        <div class="kv">
+          <div class="k">run_id</div>
+          <div class="v mono" id="selectedRunId">(all)</div>
+        </div>
+        <div class="kv">
+          <div class="k">trace_ids</div>
+          <div class="v mono" id="selectedTraceIds">(n/a)</div>
+        </div>
+        <pre id="deltasPre" class="mono small pre"></pre>
+      </div>
+
       <div class="row">
         <div class="col">
           <label for="nodeFilter">Node filter</label>

--- a/fieldgrade_ui/watcher.py
+++ b/fieldgrade_ui/watcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import time
+import uuid
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -40,7 +41,12 @@ def scan_and_enqueue(uploads_dir: Path, label: str = "watch") -> int:
         # update state first to prevent duplicate enqueues on crash loops
         state[key] = sig
         save_state(state)
-        create_job(jobs_db_path(), "pipeline", {"upload_path": key, "label": label})
+        run_id = uuid.uuid4().hex
+        create_job(
+            jobs_db_path(),
+            "pipeline",
+            {"upload_path": key, "label": label, "run_id": run_id},
+        )
         enq += 1
     return enq
 

--- a/fieldgrade_ui/worker.py
+++ b/fieldgrade_ui/worker.py
@@ -4,6 +4,7 @@ import os
 import re
 import time
 import json
+import uuid
 from pathlib import Path
 
 from .config import jobs_db_path, repo_root
@@ -132,8 +133,16 @@ def run_once() -> bool:
         if kind == "pipeline":
             upload_path = _sandbox_upload_path(Path(params["upload_path"]))
             label = str(params.get("label", "run"))
+            run_id = str(params.get("run_id") or "").strip() or uuid.uuid4().hex
             log("starting pipeline job")
-            result = run_termite_to_ecology_pipeline(repo_root(), upload_path=upload_path, label=label, log=log)
+            log(f"run_id={run_id}")
+            result = run_termite_to_ecology_pipeline(
+                repo_root(),
+                upload_path=upload_path,
+                label=label,
+                run_id=run_id,
+                log=log,
+            )
             succeed_job(db_path, job_id, result)
         else:
             raise RuntimeError(f"unknown job kind={kind}")

--- a/mite_ecology/mite_ecology/graph_delta.py
+++ b/mite_ecology/mite_ecology/graph_delta.py
@@ -99,6 +99,13 @@ def append_graph_delta_event(
     ops_payload = _canonical_jsonl(ops_lines)
     ops_hash = sha256_str(ops_payload)
 
+    # Always attach run context (may come from env vars or contextvars).
+    from .run_context import current
+
+    ctx = current(create=True)
+    rid = str(run_id) if run_id is not None else ctx.run_id
+    tid = str(trace_id) if trace_id is not None else ctx.trace_id
+
     prev = latest_event_hash(ledger_path)
     body = {
         "v": 1,
@@ -107,8 +114,8 @@ def append_graph_delta_event(
         "payload": {
             "source": str(source),
             "context_node_id": (str(context_node_id) if context_node_id is not None else None),
-            "run_id": (str(run_id) if run_id is not None else None),
-            "trace_id": (str(trace_id) if trace_id is not None else None),
+            "run_id": rid,
+            "trace_id": tid,
             "ops_kind": "kg_delta.jsonl",
             "ops_payload": ops_payload,
             "ops_hash": ops_hash,

--- a/mite_ecology/mite_ecology/run_context.py
+++ b/mite_ecology/mite_ecology/run_context.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Iterator, Optional
+
+
+_run_id_var: ContextVar[Optional[str]] = ContextVar("mite_run_id", default=None)
+_trace_id_var: ContextVar[Optional[str]] = ContextVar("mite_trace_id", default=None)
+
+
+@dataclass(frozen=True)
+class RunContext:
+    run_id: str
+    trace_id: str
+
+    def asdict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _env_run_id() -> Optional[str]:
+    return (os.environ.get("FG_RUN_ID") or os.environ.get("FIELDGRADE_RUN_ID") or "").strip() or None
+
+
+def _env_trace_id() -> Optional[str]:
+    return (os.environ.get("FG_TRACE_ID") or os.environ.get("FIELDGRADE_TRACE_ID") or "").strip() or None
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex
+
+
+def get_run_id(*, create: bool = True) -> str:
+    rid = _run_id_var.get() or _env_run_id()
+    if rid:
+        return rid
+    if not create:
+        raise RuntimeError("run_id is not set")
+    rid = _new_id()
+    _run_id_var.set(rid)
+    return rid
+
+
+def get_trace_id(*, create: bool = True) -> str:
+    tid = _trace_id_var.get() or _env_trace_id()
+    if tid:
+        return tid
+    if not create:
+        raise RuntimeError("trace_id is not set")
+    tid = _new_id()
+    _trace_id_var.set(tid)
+    return tid
+
+
+def current(*, create: bool = True) -> RunContext:
+    return RunContext(run_id=get_run_id(create=create), trace_id=get_trace_id(create=create))
+
+
+@contextmanager
+def run_context(*, run_id: Optional[str] = None, trace_id: Optional[str] = None) -> Iterator[RunContext]:
+    """Temporarily set run/trace IDs for the current context.
+
+    This is primarily for in-process pipelines and tests.
+    """
+    rid = (run_id or "").strip() or None
+    tid = (trace_id or "").strip() or None
+
+    tok_r = _run_id_var.set(rid)
+    tok_t = _trace_id_var.set(tid)
+    try:
+        yield current(create=True)
+    finally:
+        _run_id_var.reset(tok_r)
+        _trace_id_var.reset(tok_t)

--- a/mite_ecology/tests/test_graph_delta_ledger.py
+++ b/mite_ecology/tests/test_graph_delta_ledger.py
@@ -75,3 +75,17 @@ def test_replay_equivalence(tmp_path: Path) -> None:
     h2 = snapshot_hash(con2)
 
     assert h1 == h2
+
+
+def test_event_has_run_context(tmp_path: Path) -> None:
+    lp = tmp_path / "graph_delta_ledger.jsonl"
+    ops = [json.dumps({"op": "ADD_NODE", "id": "n1", "type": "Thing", "attrs": {"x": 1}})]
+    append_graph_delta_event(lp, source="TEST", ops_lines=ops)
+
+    recs = list(iter_ledger(lp))
+    assert len(recs) == 1
+    payload = recs[0].get("payload") or {}
+    assert isinstance(payload.get("run_id"), str)
+    assert payload.get("run_id")
+    assert isinstance(payload.get("trace_id"), str)
+    assert payload.get("trace_id")

--- a/schemas/graph_delta_event_v1.json
+++ b/schemas/graph_delta_event_v1.json
@@ -11,12 +11,12 @@
     "event_hash": {"type": "string"},
     "payload": {
       "type": "object",
-      "required": ["ops_kind", "ops_payload", "ops_hash", "source"],
+      "required": ["ops_kind", "ops_payload", "ops_hash", "source", "run_id", "trace_id"],
       "properties": {
         "source": {"type": "string"},
         "context_node_id": {"type": ["string", "null"]},
-        "run_id": {"type": ["string", "null"]},
-        "trace_id": {"type": ["string", "null"]},
+        "run_id": {"type": "string"},
+        "trace_id": {"type": "string"},
         "ops_kind": {"type": "string", "const": "kg_delta.jsonl"},
         "ops_payload": {"type": "string", "description": "Canonicalized JSONL of KG ops"},
         "ops_hash": {"type": "string", "description": "sha256_hex(canonical_ops_payload)"},

--- a/schemas/ldna_registry.yaml
+++ b/schemas/ldna_registry.yaml
@@ -19,7 +19,7 @@ schemas:
 - uri: ldna://json/graph_delta_event@1.0.0
   description: GraphDelta append-only ledger event (hash-chained)
   path: schemas/graph_delta_event_v1.json
-  sha256: 08630866089a71926f5403ff5e9b1f89f9dedda4b1469d2bdbabb3b56b0be0b8
+  sha256: e9f05316c1fa020630757e91ff5f808c9f682537ba34f9f70465354e8e4886f4
 - uri: ldna://yaml/registry_components@1.0.0
   description: Registry catalog (components)
   path: schemas/registry_components_v1.json


### PR DESCRIPTION
## Summary
- 

## Scope
- [ ] One step only (no unrelated changes)
- [ ] No UX/features added beyond the step

## Determinism / Provenance
- [ ] No generated `runtime/` state or local DBs committed
- [ ] No artifacts/exports committed (`*/artifacts/`, `resources/prompt_cache_prompts/`, etc.)
- [ ] Any content-hash/canonicalization logic changes are explicitly called out

## Security / Secrets
- [ ] No secrets committed (`.env`, tokens, private keys)
- [ ] Auth/API behavior preserved (token required when binding non-loopback)

## Validation
- [ ] `pytest -q` (or relevant targeted tests) passes locally
- [ ] Docker Compose smoke path still works if applicable

## Notes for reviewer
-

## Summary by Sourcery

Add run/trace ID propagation across the pipeline and expose GraphDelta ledger data in the UI.

New Features:
- Expose GraphDelta ledger runs and events via new /api/runs and /api/deltas endpoints.
- Add a GraphDelta ledger viewer to the Graph Explorer UI with run-based filtering and delta inspection.

Enhancements:
- Propagate stable run_id and stage-specific trace_ids through pipeline jobs, including subprocesses and in-process library flows, via environment variables and a new run_context helper.
- Record run_id and trace_id on all GraphDelta events by default, derived from context or environment.
- Include run_id in pipeline job creation, results, and watcher-enqueued jobs for better correlation.

Tests:
- Add a test ensuring GraphDelta ledger events always include run_id and trace_id fields.