### PR TITLE
Add Fieldgrade proposal-readiness pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,185 @@
+# AGENTS.md — Fieldgrade Proposal-Readiness Instructions
+
+## Project Identity
+
+Fieldgrade is a local-first evidence, provenance, and proposal-readiness substrate within the wider CFX Stack.
+
+Its function is to witness, seal, classify, export, and review evidence-bearing research objects.
+
+Fieldgrade is not a generic notes app.
+Fieldgrade is not merely a document viewer.
+Fieldgrade is not the whole CFX Stack.
+Fieldgrade is the evidence/provenance layer that makes research artifacts auditable, admissible, and proposal-ready.
+
+## Current Sprint Objective
+
+Finalise Fieldgrade for proposal readiness.
+
+The repository must become suitable for:
+- Innovate UK Frontier AI Benchmarking Datasets
+- Innovate UK Frontier AI Discovery
+- Evidence-governance, provenance, research-infrastructure, and AI-audit proposals
+- Later HXMM / advanced-materials demonstrator proposals
+
+## Product Thesis
+
+Fieldgrade enables frontier-AI and research teams to create trustworthy datasets and benchmark artifacts by preserving:
+- source provenance
+- ingestion metadata
+- human/AI annotations
+- audit decisions
+- claim status
+- admissibility tier
+- exportable evidence bundles
+- review trails
+- reproducible demo datasets
+
+## Proposal-Ready Definition
+
+The sprint is complete only when the repo contains:
+
+1. A working local demo
+2. A demo dataset
+3. A clear README
+4. A proposal narrative
+5. A technical architecture document
+6. A risk and ethics register
+7. A funding-fit matrix
+8. A demo script
+9. Screenshots or screenshot instructions
+10. A validation script
+11. A readiness audit
+12. A final changelog
+
+## Required Proposal Pack
+
+Create or update the following files:
+
+- `docs/proposal/FIELDGRADE_READINESS_AUDIT.md`
+- `docs/proposal/FIELDGRADE_PROPOSAL_NARRATIVE.md`
+- `docs/proposal/FIELDGRADE_TECHNICAL_ARCHITECTURE.md`
+- `docs/proposal/FIELDGRADE_DEMO_SCRIPT.md`
+- `docs/proposal/FIELDGRADE_FUNDING_FIT_MATRIX.md`
+- `docs/proposal/FIELDGRADE_RISK_ETHICS_REGISTER.md`
+- `docs/proposal/FIELDGRADE_DATA_GOVERNANCE.md`
+- `docs/proposal/FIELDGRADE_12_WEEK_ROADMAP.md`
+- `docs/proposal/FIELDGRADE_PARTNER_BRIEF.md`
+- `docs/proposal/FIELDGRADE_ONE_PAGE_SUMMARY.md`
+- `docs/proposal/README_PROPOSAL_PACK.md`
+
+Create or update these demo assets:
+
+- `data/demo/fieldgrade_demo_sources.json`
+- `data/demo/fieldgrade_demo_annotations.json`
+- `data/demo/fieldgrade_demo_audit_trail.json`
+- `data/demo/fieldgrade_demo_export_manifest.json`
+- `outputs/proposal_pack/README.md`
+
+Create or update validation tools:
+
+- `scripts/validate_fieldgrade_pack.py`
+- `scripts/generate_demo_manifest.py`
+- `scripts/check_proposal_readiness.py`
+
+## Engineering Rules
+
+Before changing code:
+1. Inspect the repo structure.
+2. Identify the actual runtime entry points.
+3. Identify existing build, test, lint, and run commands.
+4. Record findings in `docs/proposal/FIELDGRADE_READINESS_AUDIT.md`.
+5. Do not invent commands if the repo already defines them.
+
+When changing code:
+1. Prefer small, reviewable changes.
+2. Preserve existing architecture unless broken.
+3. Avoid adding large dependencies without justification.
+4. Keep Fieldgrade local-first.
+5. Do not hard-code private API keys.
+6. Do not add live network calls unless the project already supports them.
+7. Make demo data synthetic or clearly public-domain/sample data.
+8. Keep proposal artifacts separate from runtime code.
+
+## Evidence and Governance Rules
+
+Every demo artifact should include:
+- object ID
+- title
+- source type
+- provenance note
+- ingestion timestamp
+- evidence status
+- review status
+- admissibility tier
+- export hash or checksum where feasible
+- human-readable explanation
+
+Use these admissibility tiers:
+- canonical
+- controlled_extension
+- speculative_projective_extension
+- rejected
+- audit_only
+- unknown
+
+Use these review states:
+- raw
+- ingested
+- annotated
+- reviewed
+- exported
+- superseded
+
+## Funding-Framing Rules
+
+For Frontier AI Benchmarking Datasets:
+Frame Fieldgrade as a FAIR benchmark and dataset-governance substrate for evaluating frontier-AI research agents.
+
+For Frontier AI Discovery:
+Frame Fieldgrade as the evidence and audit layer for autonomous scientific discovery workflows.
+
+For advanced-materials proposals:
+Frame Fieldgrade as the provenance layer for experiment batches, microscopy, sensor traces, laminate recipes, QA data, and end-user review.
+
+## Documentation Style
+
+Use precise, proposal-ready language.
+
+Avoid overclaiming.
+
+Do not present speculative CAO, HXMM, QFIM-Triad, or CFX concepts as proven scientific facts.
+
+Use cautious phrases:
+- "evidence-governed"
+- "audit-ready"
+- "local-first"
+- "human-reviewable"
+- "provenance-preserving"
+- "benchmark-oriented"
+- "proposal-ready demonstrator"
+- "controlled speculative extension"
+
+Avoid unsupported phrases:
+- "AGI"
+- "consciousness transfer"
+- "quantum proof"
+- "metamaterial breakthrough"
+- "fully autonomous science"
+- "guaranteed trust"
+
+## Verification Rules
+
+Before declaring completion:
+1. Run the available tests.
+2. Run lint/type checks if available.
+3. Run the local demo if possible.
+4. Run `scripts/check_proposal_readiness.py`.
+5. Confirm all required files exist.
+6. Confirm proposal documents cross-reference actual repo behavior.
+7. Confirm no fake features are described as implemented.
+8. Produce a final summary with:
+   - files changed
+   - commands run
+   - passing checks
+   - known gaps
+   - next recommended action

--- a/README.md
+++ b/README.md
@@ -538,3 +538,36 @@ http://127.0.0.1:8787/
 ## Android (Termux)
 
 See `TERMUX.md` for a Termux-native install and run flow (including scripts).
+
+## Local setup for the proposal-ready demonstrator
+
+Fieldgrade now includes a proposal-readiness pack for funder and RFP review. The pack is grounded in the existing local-first evidence runtime and adds synthetic frontier-AI, research-agent, and advanced-materials demo records.
+
+From the repository root, refresh and validate the proposal demo assets:
+
+```bash
+python scripts/generate_demo_manifest.py
+python scripts/check_proposal_readiness.py
+```
+
+Key proposal-readiness paths:
+
+- Proposal pack: `docs/proposal/`
+- Synthetic demo data: `data/demo/`
+- Proposal output landing area: `outputs/proposal_pack/`
+- Readiness validation: `scripts/check_proposal_readiness.py`
+
+For the full local CLI demonstration, use the existing run path:
+
+```bash
+./run_demo.sh
+```
+
+For the local UI/API path after installing the workspace, initialise and serve Fieldgrade:
+
+```bash
+python -m fieldgrade_ui init
+python -m fieldgrade_ui serve
+```
+
+The proposal demo data is synthetic. Treat Fieldgrade as a proposal-ready demonstrator unless a partner deployment, security review, and domain validation support stronger production claims.

--- a/data/demo/fieldgrade_demo_annotations.json
+++ b/data/demo/fieldgrade_demo_annotations.json
@@ -1,0 +1,32 @@
+[
+  {
+    "annotation_id": "FG-ANN-001",
+    "object_id": "FG-DEMO-001",
+    "author_type": "human",
+    "created_at": "2026-05-15T00:20:00Z",
+    "admissibility_tier": "controlled_extension",
+    "review_state": "annotated",
+    "content": "Object suitable for demonstrating provenance capture and benchmark trace review.",
+    "human_readable_explanation": "Reviewer confirms this is a synthetic benchmark-governance example, not a measured benchmark result."
+  },
+  {
+    "annotation_id": "FG-ANN-002",
+    "object_id": "FG-DEMO-002",
+    "author_type": "human",
+    "created_at": "2026-05-15T00:25:00Z",
+    "admissibility_tier": "audit_only",
+    "review_state": "annotated",
+    "content": "AI-generated claim must remain audit-only until external sources and methodology are reviewed.",
+    "human_readable_explanation": "Shows how Fieldgrade can separate AI assistance from approved evidence."
+  },
+  {
+    "annotation_id": "FG-ANN-003",
+    "object_id": "FG-DEMO-003",
+    "author_type": "human",
+    "created_at": "2026-05-15T00:30:00Z",
+    "admissibility_tier": "audit_only",
+    "review_state": "reviewed",
+    "content": "Useful as a proposal example only; not a real experimental result.",
+    "human_readable_explanation": "Keeps materials-demo language controlled and avoids unsupported scientific claims."
+  }
+]

--- a/data/demo/fieldgrade_demo_audit_trail.json
+++ b/data/demo/fieldgrade_demo_audit_trail.json
@@ -1,0 +1,35 @@
+[
+  {
+    "event_id": "FG-AUD-001",
+    "object_id": "FG-DEMO-001",
+    "event_type": "ingested",
+    "actor": "proposal_demo_operator",
+    "timestamp": "2026-05-15T00:00:00Z",
+    "review_state": "ingested",
+    "admissibility_tier": "controlled_extension",
+    "decision": "accepted_for_demo",
+    "human_readable_explanation": "Synthetic benchmark trace added to demonstrate dataset curation provenance."
+  },
+  {
+    "event_id": "FG-AUD-002",
+    "object_id": "FG-DEMO-002",
+    "event_type": "annotation_added",
+    "actor": "proposal_demo_reviewer",
+    "timestamp": "2026-05-15T00:25:00Z",
+    "review_state": "annotated",
+    "admissibility_tier": "audit_only",
+    "decision": "requires_source_review",
+    "human_readable_explanation": "Reviewer marks the synthetic research-agent output as requiring independent validation."
+  },
+  {
+    "event_id": "FG-AUD-003",
+    "object_id": "FG-DEMO-003",
+    "event_type": "review_decision",
+    "actor": "proposal_demo_reviewer",
+    "timestamp": "2026-05-15T00:35:00Z",
+    "review_state": "reviewed",
+    "admissibility_tier": "audit_only",
+    "decision": "proposal_example_only",
+    "human_readable_explanation": "Materials batch record may be used for walkthroughs but not as empirical evidence."
+  }
+]

--- a/data/demo/fieldgrade_demo_export_manifest.json
+++ b/data/demo/fieldgrade_demo_export_manifest.json
@@ -1,0 +1,75 @@
+{
+  "manifest_id": "FG-DEMO-MANIFEST-2026-05-15",
+  "created_at": "2026-05-15T15:02:13Z",
+  "created_by": "scripts/generate_demo_manifest.py",
+  "bundle_title": "Fieldgrade proposal-readiness synthetic evidence bundle",
+  "bundle_scope": "Proposal-ready demonstrator for evidence-governed frontier-AI research workflows.",
+  "synthetic_data_notice": "All objects in this manifest are synthetic proposal-demo records and must not be represented as real benchmark, lab, or operational data.",
+  "objects": [
+    {
+      "object_id": "FG-DEMO-001",
+      "title": "Synthetic frontier-AI benchmark task trace",
+      "source_type": "synthetic_json",
+      "provenance_note": "Synthetic demo object created for Fieldgrade proposal-readiness testing; not a real benchmark result.",
+      "ingestion_timestamp": "2026-05-15T00:00:00Z",
+      "claim_status": "demonstrator",
+      "admissibility_tier": "controlled_extension",
+      "review_state": "ingested",
+      "evidence_status": "synthetic_demo",
+      "review_status": "awaiting_human_review",
+      "annotation_count": 1,
+      "audit_event_count": 1,
+      "export_hash": "8795a70d58713cd57aa32ab3005371e37c96c85ac46ae3608a4719ffeb9192d1",
+      "human_readable_explanation": "Shows how a benchmark task trace can carry provenance, review state, and admissibility metadata before export."
+    },
+    {
+      "object_id": "FG-DEMO-002",
+      "title": "Synthetic research-agent output review",
+      "source_type": "synthetic_agent_trace",
+      "provenance_note": "Synthetic record for demonstrating human review of an AI-generated research claim; no live model output is used.",
+      "ingestion_timestamp": "2026-05-15T00:05:00Z",
+      "claim_status": "requires_review",
+      "admissibility_tier": "audit_only",
+      "review_state": "annotated",
+      "evidence_status": "synthetic_demo",
+      "review_status": "human_review_required",
+      "annotation_count": 1,
+      "audit_event_count": 1,
+      "export_hash": "5206b9226f8fac507a5f222f2f7a445c8b75614bf576695d8005849e70312620",
+      "human_readable_explanation": "Demonstrates that AI-assisted claims remain audit-only until a reviewer verifies sources and limitations."
+    },
+    {
+      "object_id": "FG-DEMO-003",
+      "title": "Synthetic advanced-materials batch record",
+      "source_type": "synthetic_lab_record",
+      "provenance_note": "Synthetic record for demonstrating experiment-batch evidence tracking; not a real experimental result.",
+      "ingestion_timestamp": "2026-05-15T00:10:00Z",
+      "claim_status": "demonstrator",
+      "admissibility_tier": "audit_only",
+      "review_state": "reviewed",
+      "evidence_status": "synthetic_demo",
+      "review_status": "proposal_example_only",
+      "annotation_count": 1,
+      "audit_event_count": 1,
+      "export_hash": "eb4134b12fc8dce43ff995fbeb057f04391f3cff33bd57936eef0ae3dec2ce84",
+      "human_readable_explanation": "Illustrates batch-provenance fields that could later be connected to real lab records, microscopy, QA, or sensor data."
+    }
+  ],
+  "files": [
+    {
+      "path": "data/demo/fieldgrade_demo_sources.json",
+      "sha256": "eacded3c70438a421df62a20f8a9c8b509630ec89e3efebc121676dcdc7f8f80",
+      "bytes": 2277
+    },
+    {
+      "path": "data/demo/fieldgrade_demo_annotations.json",
+      "sha256": "61a1714229438fdedb2f61c4e514ca5e39d16993097a5b78bcac840d1dcf4e4c",
+      "bytes": 1330
+    },
+    {
+      "path": "data/demo/fieldgrade_demo_audit_trail.json",
+      "sha256": "aa19f7a19e87c5d37e97e392dfbc8bc8a49985dfada2a9611aae36e9757e9b6f",
+      "bytes": 1263
+    }
+  ]
+}

--- a/data/demo/fieldgrade_demo_sources.json
+++ b/data/demo/fieldgrade_demo_sources.json
@@ -1,0 +1,47 @@
+[
+  {
+    "object_id": "FG-DEMO-001",
+    "title": "Synthetic frontier-AI benchmark task trace",
+    "source_type": "synthetic_json",
+    "domain": "frontier_ai_benchmarking",
+    "provenance_note": "Synthetic demo object created for Fieldgrade proposal-readiness testing; not a real benchmark result.",
+    "ingestion_timestamp": "2026-05-15T00:00:00Z",
+    "claim_status": "demonstrator",
+    "admissibility_tier": "controlled_extension",
+    "review_state": "ingested",
+    "evidence_status": "synthetic_demo",
+    "review_status": "awaiting_human_review",
+    "risk_flags": [],
+    "human_readable_explanation": "Shows how a benchmark task trace can carry provenance, review state, and admissibility metadata before export."
+  },
+  {
+    "object_id": "FG-DEMO-002",
+    "title": "Synthetic research-agent output review",
+    "source_type": "synthetic_agent_trace",
+    "domain": "frontier_ai_discovery",
+    "provenance_note": "Synthetic record for demonstrating human review of an AI-generated research claim; no live model output is used.",
+    "ingestion_timestamp": "2026-05-15T00:05:00Z",
+    "claim_status": "requires_review",
+    "admissibility_tier": "audit_only",
+    "review_state": "annotated",
+    "evidence_status": "synthetic_demo",
+    "review_status": "human_review_required",
+    "risk_flags": ["ai_generated_claim", "requires_source_validation"],
+    "human_readable_explanation": "Demonstrates that AI-assisted claims remain audit-only until a reviewer verifies sources and limitations."
+  },
+  {
+    "object_id": "FG-DEMO-003",
+    "title": "Synthetic advanced-materials batch record",
+    "source_type": "synthetic_lab_record",
+    "domain": "advanced_materials",
+    "provenance_note": "Synthetic record for demonstrating experiment-batch evidence tracking; not a real experimental result.",
+    "ingestion_timestamp": "2026-05-15T00:10:00Z",
+    "claim_status": "demonstrator",
+    "admissibility_tier": "audit_only",
+    "review_state": "reviewed",
+    "evidence_status": "synthetic_demo",
+    "review_status": "proposal_example_only",
+    "risk_flags": ["requires_real_lab_validation"],
+    "human_readable_explanation": "Illustrates batch-provenance fields that could later be connected to real lab records, microscopy, QA, or sensor data."
+  }
+]

--- a/docs/proposal/FIELDGRADE_12_WEEK_ROADMAP.md
+++ b/docs/proposal/FIELDGRADE_12_WEEK_ROADMAP.md
@@ -1,0 +1,49 @@
+# Fieldgrade 12-Week Roadmap
+
+## Goal
+
+Convert the proposal-ready demonstrator into a partner-ready pilot for evidence-governed frontier-AI research workflows.
+
+## Weeks 1-2: Partner discovery and scope lock
+
+- Select one primary funding route and one partner scenario.
+- Confirm target users, evidence objects, review decisions, and export needs.
+- Define data governance, licensing, privacy, and review responsibilities.
+
+## Weeks 3-4: Demo schema hardening
+
+- Extend demo object schemas for the chosen domain.
+- Add partner-specific fields without breaking local-first operation.
+- Create validation fixtures for admissibility tiers and review states.
+
+## Weeks 5-6: Workflow integration
+
+- Connect synthetic proposal records to the existing Termite and Fieldgrade UI/API run paths where useful.
+- Add export-template improvements for benchmark governance or discovery review.
+- Capture screenshots and reviewer walkthroughs.
+
+## Weeks 7-8: Review and assurance layer
+
+- Add clearer reviewer roles, decision reasons, limitation notes, and audit summaries.
+- Trial a controlled AI-use record with human review.
+- Validate benchmark contamination and licensing controls.
+
+## Weeks 9-10: Pilot packaging
+
+- Prepare partner onboarding guide, local setup path, demo dataset, and acceptance criteria.
+- Run the local demo on a clean machine or container.
+- Produce a sample evidence bundle and proposal appendix.
+
+## Weeks 11-12: Evaluation and submission pack
+
+- Run readiness checks and available test suites.
+- Finalise funder narrative, technical appendix, risk register, and delivery plan.
+- Produce partner letter inputs, budget assumptions, and a final readiness audit.
+
+## Success criteria
+
+- Proposal pack passes validation.
+- Partner can understand and run the demo path.
+- Claims remain grounded in implemented or clearly planned behavior.
+- Synthetic examples are not represented as real evidence.
+- Remaining production gaps are documented with owners and next steps.

--- a/docs/proposal/FIELDGRADE_DATA_GOVERNANCE.md
+++ b/docs/proposal/FIELDGRADE_DATA_GOVERNANCE.md
@@ -1,0 +1,37 @@
+# Fieldgrade Data Governance
+
+## Governance principle
+
+Fieldgrade should preserve evidence provenance without pretending that capture alone proves truth. Source material, metadata, annotations, AI-use records, review decisions, and export manifests should remain distinct so reviewers can inspect how a claim was assembled.
+
+## Data categories
+
+- Synthetic proposal-demo records under `data/demo/`.
+- Local runtime evidence ingested through Termite Fieldpack.
+- Review and analysis records processed through mite_ecology.
+- Fieldgrade UI/API records for jobs, governance, registries, and readiness surfaces.
+- Export bundles, manifests, reports, and audit-pack outputs.
+
+## Provenance controls
+
+Every proposal-demo object includes object ID, title, source type, provenance note, ingestion timestamp, claim status, admissibility tier, review state, evidence status, review status, risk flags, and human-readable explanation. Generated manifests add object-level export hashes and file-level SHA-256 checksums.
+
+## Human review controls
+
+AI-assisted outputs and speculative extensions should remain in `audit_only`, `controlled_extension`, or `speculative_projective_extension` tiers until a human reviewer verifies sources, limitations, and intended use. Review decisions should identify the actor, timestamp, decision, and reason.
+
+## Privacy and sensitivity
+
+The proposal demo uses synthetic data only. Real deployments should define data-classification rules before ingestion, keep sensitive data local where possible, avoid unnecessary external transfer, and document retention and deletion rules.
+
+## Licensing and dataset reuse
+
+Proposal and benchmark datasets should record license, source permission, transformation history, and reuse constraints. Public or partner datasets should not be mixed into benchmark artifacts unless their license and provenance support the intended use.
+
+## Benchmark contamination controls
+
+Benchmark-oriented proposals should separate training, evaluation, validation, and demonstration artifacts. AI-generated summaries should be labelled, cached where possible, and reviewed so benchmark records do not silently absorb unverified model output.
+
+## Export controls
+
+Export manifests should include file checksums, object export hashes, synthetic-data notices where applicable, and a clear statement of admissibility status. Exports should distinguish proposal examples from operational evidence.

--- a/docs/proposal/FIELDGRADE_DEMO_SCRIPT.md
+++ b/docs/proposal/FIELDGRADE_DEMO_SCRIPT.md
@@ -1,0 +1,64 @@
+# Fieldgrade Proposal Demo Script
+
+## Demo objective
+
+Show that Fieldgrade can organise synthetic frontier-AI and research-governance artifacts into a human-reviewable evidence bundle with provenance, admissibility, annotations, audit decisions, and an export manifest.
+
+## Preparation
+
+From the repository root:
+
+```bash
+python scripts/generate_demo_manifest.py
+python scripts/check_proposal_readiness.py
+```
+
+Optional runtime demonstration:
+
+```bash
+./run_demo.sh
+```
+
+For the local UI/API, install the workspace and run:
+
+```bash
+python -m fieldgrade_ui init
+python -m fieldgrade_ui serve
+```
+
+## Walkthrough
+
+### 1. Open the synthetic source objects
+
+Open `data/demo/fieldgrade_demo_sources.json`. Explain that every record is synthetic and includes object ID, source type, provenance note, claim status, admissibility tier, review state, and risk flags.
+
+### 2. Show annotations
+
+Open `data/demo/fieldgrade_demo_annotations.json`. Explain that Fieldgrade separates source records from review annotations so AI-assisted or speculative claims can remain controlled until reviewed.
+
+### 3. Show audit trail
+
+Open `data/demo/fieldgrade_demo_audit_trail.json`. Highlight event ID, actor, timestamp, decision, review state, and admissibility tier.
+
+### 4. Generate export manifest
+
+Run `python scripts/generate_demo_manifest.py`. Open `data/demo/fieldgrade_demo_export_manifest.json` and show object-level export hashes and file checksums.
+
+### 5. Run readiness validation
+
+Run `python scripts/check_proposal_readiness.py`. Use the PASS output as the proposal-readiness check for required files, JSON parsing, object fields, placeholder scanning, and README local setup coverage.
+
+### 6. Describe runtime path honestly
+
+Explain that the existing repo also includes Termite, mite_ecology, and Fieldgrade UI/API runtime paths. The synthetic proposal demo is designed for funder review and does not claim that synthetic records are real benchmark, lab, or operational evidence.
+
+## Screenshot instructions
+
+Capture screenshots of:
+
+1. repository root with `docs/proposal/`, `data/demo/`, and `scripts/` visible;
+2. the generated export manifest showing object hashes;
+3. terminal output from `python scripts/check_proposal_readiness.py`;
+4. optional local UI at `http://127.0.0.1:8787` after running the UI serve command.
+
+Store screenshots under `docs/screenshots/` if they are added to a proposal submission.

--- a/docs/proposal/FIELDGRADE_FUNDING_FIT_MATRIX.md
+++ b/docs/proposal/FIELDGRADE_FUNDING_FIT_MATRIX.md
@@ -1,0 +1,22 @@
+# Fieldgrade Funding-Fit Matrix
+
+| Call | Fieldgrade fit | Evidence needed |
+|---|---|---|
+| Frontier AI Benchmarking Datasets | FAIR benchmark governance and dataset provenance | Synthetic demo dataset, export manifest, validation script, partner benchmark scenario |
+| Frontier AI Discovery | Audit layer for AI-assisted discovery workflows | Runtime demo, research-agent trace review, risk controls, human-review workflow |
+| Biosecurity governance | Evidence-chain integrity and controlled review of sensitive claims | Risk controls, privacy boundaries, admissibility policy, partner-specific data handling |
+| Advanced materials | Batch provenance for recipes, QA records, microscopy, sensor traces, and reviewer decisions | Materials demo, lab partner, domain schema extension, validation plan |
+| Cyber / critical sectors | Tamper-evident audit and human-reviewable AI-use records | Security case, local deployment model, access-control plan, audit export evidence |
+| KTP | Academic productisation of a local-first evidence-governance tool | Partner brief, 12-week roadmap, user research plan, pilot package |
+
+## Priority
+
+1. Frontier AI Benchmarking Datasets.
+2. Frontier AI Discovery.
+3. KTP partner route.
+4. Advanced-materials provenance route.
+5. Cyber or regulated-sector route.
+
+## Recommended positioning
+
+Use the phrase “proposal-ready demonstrator for evidence-governed frontier-AI research workflows.” Avoid describing Fieldgrade as production-certified or regulator-approved until real deployment evidence supports that claim.

--- a/docs/proposal/FIELDGRADE_ONE_PAGE_SUMMARY.md
+++ b/docs/proposal/FIELDGRADE_ONE_PAGE_SUMMARY.md
@@ -1,0 +1,39 @@
+# Fieldgrade One-Page Summary
+
+## Short description
+
+Fieldgrade is a local-first evidence and provenance layer for frontier-AI research workflows. It helps teams convert research artifacts, benchmark slices, annotations, review decisions, AI-assisted outputs, and export manifests into auditable evidence bundles.
+
+## Problem
+
+Frontier-AI research and autonomous discovery workflows produce many intermediate artifacts. Those artifacts are often hard to trace, review, reproduce, and reuse. Weak provenance reduces trust in benchmark datasets, slows proposal assembly, and makes audit or assurance evidence harder to defend.
+
+## Solution
+
+Fieldgrade provides a structured evidence workflow:
+
+1. ingest source artifacts,
+2. preserve provenance metadata,
+3. classify claim and admissibility status,
+4. record human and AI-use annotations,
+5. maintain review and audit trails,
+6. export reviewable evidence bundles, and
+7. support proposal, benchmark, and governance workflows.
+
+## Demonstrator status
+
+The repository already contains local-first evidence tooling, a FastAPI UI/API shell, provenance-oriented Termite Fieldpack workflows, review and analysis support in mite_ecology, schemas, deployment guides, and sample export materials. This proposal pack adds a synthetic frontier-AI and research-governance demo dataset plus validation scripts so the repo can be reviewed as a proposal-ready demonstrator.
+
+## Best funding framing
+
+Fieldgrade is best positioned as:
+
+- a FAIR benchmark governance layer for Frontier AI Benchmarking Datasets,
+- an evidence and audit layer for Frontier AI Discovery workflows,
+- a local-first provenance substrate for research-agent review,
+- a reusable evidence layer for future advanced-materials demonstrators, and
+- a partner-friendly infrastructure component for university, RTO, SME, and KTP routes.
+
+## Responsible claim boundary
+
+Fieldgrade should be described as a proposal-ready demonstrator, not as a production-certified compliance system. It supports audit preparation and human review; it does not replace auditors, regulators, QA managers, legal advice, scientific validation, or domain experts.

--- a/docs/proposal/FIELDGRADE_PARTNER_BRIEF.md
+++ b/docs/proposal/FIELDGRADE_PARTNER_BRIEF.md
@@ -1,0 +1,43 @@
+# Fieldgrade Partner Brief
+
+## What Fieldgrade offers partners
+
+Fieldgrade offers a local-first evidence and provenance demonstrator for teams that need to make research artifacts, benchmark data, AI-assisted outputs, and review decisions easier to audit and explain.
+
+## Best-fit partners
+
+- Universities coordinating frontier-AI evaluation or discovery workflows.
+- Research and technology organisations managing multi-partner evidence packs.
+- SMEs preparing funding bids, assurance packs, or RFP responses.
+- Advanced-materials teams needing batch, sensor, microscopy, QA, and reviewer provenance.
+- Organisations that need accountable AI-use records without handing sensitive data to a hosted system by default.
+
+## What a partner pilot would test
+
+1. Which evidence objects matter for the partner domain.
+2. How source provenance and licensing should be recorded.
+3. Which review states and admissibility tiers are useful.
+4. Whether export manifests support proposal, audit, or dataset-review needs.
+5. Which runtime path is easiest for partner users.
+
+## Partner inputs needed
+
+- One domain scenario.
+- Example non-sensitive or synthetic records.
+- Review criteria and decision roles.
+- Expected export format.
+- Data governance constraints.
+- Feedback from at least one technical reviewer and one operational reviewer.
+
+## Proposed pilot output
+
+- Partner-specific demo dataset.
+- Evidence workflow map.
+- Export manifest and sample evidence pack.
+- Risk and ethics addendum.
+- Screenshot walkthrough.
+- Pilot-readiness report.
+
+## Claim boundary
+
+Fieldgrade supports evidence governance and audit preparation. It does not certify compliance, validate scientific claims, or replace qualified reviewers.

--- a/docs/proposal/FIELDGRADE_PROPOSAL_NARRATIVE.md
+++ b/docs/proposal/FIELDGRADE_PROPOSAL_NARRATIVE.md
@@ -1,0 +1,80 @@
+# Fieldgrade Proposal Narrative
+
+## Short description
+
+Fieldgrade is a local-first evidence and provenance layer for frontier-AI research workflows. It helps teams convert research artifacts, datasets, benchmark slices, annotations, review decisions, and AI-generated outputs into auditable evidence bundles.
+
+## Problem
+
+Frontier-AI research and autonomous discovery workflows generate large volumes of intermediate artifacts. These artifacts are often difficult to trace, reproduce, verify, and reuse. This limits trust, slows review, weakens dataset governance, and makes funding or regulatory evidence harder to assemble.
+
+## Solution
+
+Fieldgrade provides a structured evidence workflow:
+
+1. ingest source artifacts,
+2. attach provenance metadata,
+3. classify claim status,
+4. record human and AI annotations,
+5. preserve audit trails,
+6. export evidence bundles, and
+7. support proposal, benchmark, and review workflows.
+
+## Innovation
+
+Fieldgrade combines local-first evidence capture, admissibility classification, research-object provenance, and AI-agent review traces into a single proposal-ready substrate. Its differentiator is not an unreviewed AI decision loop; it is a human-reviewable evidence trail that helps teams explain how a research object moved from raw input to reviewed export.
+
+## Target users
+
+- AI research teams preparing benchmark or evaluation datasets.
+- University consortia and RTOs coordinating cross-partner evidence.
+- SMEs preparing Innovate UK or RFP submissions.
+- Advanced-materials teams needing batch, QA, and review provenance.
+- Autonomous research platform developers that need controlled evidence review.
+- Organisations producing FAIR benchmark datasets.
+
+## Technical approach
+
+The existing repo is a Python monorepo with three main runtime areas: `termite_fieldpack/` for content-addressed evidence ingestion and bundle sealing, `mite_ecology/` for review and deterministic analysis flows, and `fieldgrade_ui/` for the governance UI/API shell. The proposal demonstrator adds synthetic evidence objects under `data/demo/` and validation scripts under `scripts/` without changing the core runtime architecture.
+
+## Near-term demonstrator
+
+The proposal-ready demonstrator shows a synthetic frontier-AI benchmark dataset moving through a Fieldgrade-style pipeline:
+
+1. raw object registration,
+2. metadata and provenance capture,
+3. annotation,
+4. claim classification,
+5. review decision,
+6. export manifest generation, and
+7. proposal evidence pack output.
+
+## Deliverables for a funded sprint
+
+- Domain-specific benchmark governance pack.
+- Partner-ready demo dataset and walkthrough.
+- Evidence schema refinements for benchmark slices and AI-agent traces.
+- Export templates for proposal evidence bundles.
+- Human-review controls for admissibility and claim status.
+- Validation scripts and lightweight readiness checks.
+- Partner pilot report and evidence-pack example.
+
+## Risks and ethics
+
+Primary risks include overclaiming, treating synthetic examples as real data, AI hallucination, privacy leakage, benchmark contamination, unclear licensing, and insufficient human review. The risk and ethics register defines mitigations: synthetic notices, admissibility tiers, review states, placeholder checks, no hard-coded secrets, local-first operation, and explicit human-review boundaries.
+
+## Commercialisation path
+
+Near-term commercialisation should focus on founder-led setup, partner pilots, funded demonstrators, and paid proposal-support packs. Fieldgrade can then move toward domain packs for benchmark governance, GovAI records, FoodQA proof packs, and advanced-materials provenance once real partner data and validation are available.
+
+## Fit to Frontier AI Benchmarking Datasets
+
+Fieldgrade fits as a FAIR benchmark governance layer. It can help define how benchmark objects, source provenance, annotations, review decisions, admissibility tiers, and export manifests are recorded and checked before publication or partner handoff.
+
+## Fit to Frontier AI Discovery
+
+Fieldgrade fits as an evidence and audit layer for AI-assisted discovery workflows. It can record research-agent outputs, source references, human review decisions, risk flags, and exportable evidence bundles so discovery claims remain inspectable and controlled.
+
+## Future extension route
+
+Advanced-materials and HXMM-adjacent use cases should be presented as future controlled extensions. The current proposal pack includes only synthetic examples and should not be represented as real scientific validation.

--- a/docs/proposal/FIELDGRADE_READINESS_AUDIT.md
+++ b/docs/proposal/FIELDGRADE_READINESS_AUDIT.md
@@ -1,0 +1,76 @@
+# Fieldgrade Readiness Audit
+
+## Audit date
+
+2026-05-15.
+
+## Current repo state
+
+Fieldgrade is a Python monorepo with existing documentation, deployment guides, schemas, tests, a FastAPI UI/API package, Termite Fieldpack evidence tooling, mite_ecology review and analysis tooling, sample exports, and shell/PowerShell demo scripts.
+
+## Actual runtime stack
+
+- Python 3.10+.
+- Root workspace managed by `pyproject.toml` and `uv`.
+- `fieldgrade_ui/` uses FastAPI and uvicorn.
+- `termite_fieldpack/` provides evidence ingestion, content-addressed storage, provenance, bundle sealing, verification, and replay.
+- `mite_ecology/` provides deterministic review/analysis pipeline behavior and review modes.
+- Root `Makefile` defines `make test` as the canonical test command.
+
+## Existing entry points inspected
+
+- `README.md` documents bootstrap, test, CLI, UI, Docker Compose, and end-to-end demo paths.
+- `run_demo.sh` runs a local Termite plus mite_ecology demonstration in `.demo_runtime`.
+- `run_demo.ps1` provides the Windows demo route.
+- `fieldgrade_ui/__main__.py` exposes UI/API commands through `python -m fieldgrade_ui` and the installed console script.
+- `scripts/bootstrap_dev.sh` and `scripts/bootstrap_dev.ps1` provide development setup.
+
+## Proposal-readiness assets added
+
+- Proposal pack under `docs/proposal/`.
+- Synthetic demo evidence records under `data/demo/`.
+- Proposal output landing file under `outputs/proposal_pack/`.
+- Validation scripts under `scripts/`.
+- Root `AGENTS.md` with durable proposal-readiness instructions.
+- A small synthetic JSONL resource used by `run_demo.sh` as an ingestible demo artifact.
+
+## Readiness rubric
+
+| Area | Pass condition | Status | Score |
+| --- | --- | --- | --- |
+| Runtime | Local demo or documented run path exists | Pass | 2 |
+| README | Clear setup path exists | Pass | 2 |
+| Demo data | Synthetic evidence set exists | Pass | 3 |
+| Governance | Risk register exists | Pass | 3 |
+| Proposal | One-page summary exists | Pass | 3 |
+| Validation | Readiness script runs | Pass | 3 |
+| Funding | Fit matrix exists | Pass | 3 |
+| Evidence | Export manifest exists | Pass | 3 |
+
+Scoring scale: 0 = absent, 1 = present but weak, 2 = usable, 3 = proposal-ready.
+
+## Current readiness score
+
+22 out of 24. Fieldgrade is honestly describable as a proposal-ready demonstrator for evidence-governed frontier-AI research workflows.
+
+## Commands identified
+
+- `bash scripts/bootstrap_dev.sh` — development setup.
+- `make test` — install workspace with `uv` and run pytest.
+- `python -m pytest -q` — test suite after dependencies are available.
+- `./run_demo.sh` — local end-to-end CLI demo.
+- `python -m fieldgrade_ui init` — initialise UI runtime.
+- `python -m fieldgrade_ui serve` — serve local UI/API.
+- `python scripts/generate_demo_manifest.py` — refresh synthetic export manifest.
+- `python scripts/check_proposal_readiness.py` — validate proposal pack.
+
+## Known gaps
+
+- The proposal demo is synthetic and should be replaced or extended with partner-approved non-sensitive records for real submissions.
+- Production hardening, access-control review, screenshot capture, and partner user testing remain future work.
+- Advanced-materials use cases are controlled extensions only until real lab validation exists.
+- The proposal pack does not claim regulatory certification or production assurance.
+
+## Stop condition status
+
+The required proposal documents, demo data, validation scripts, and audit materials are present. The readiness script checks files, JSON parsing, required object fields, placeholder text, and README local setup coverage.

--- a/docs/proposal/FIELDGRADE_RISK_ETHICS_REGISTER.md
+++ b/docs/proposal/FIELDGRADE_RISK_ETHICS_REGISTER.md
@@ -1,0 +1,28 @@
+# Fieldgrade Risk and Ethics Register
+
+| Risk | Impact | Control | Residual status |
+|---|---|---|---|
+| Synthetic records presented as real evidence | Misleading funders or partners | Synthetic-data notices in source objects, manifest, demo script, and proposal documents | Controlled for proposal demo |
+| AI hallucination treated as evidence | Unsupported claims enter datasets or proposals | AI-assisted outputs remain review-bound and can be marked `audit_only` | Requires partner operating procedure |
+| Overclaiming production readiness | Loss of trust or unsuitable deployment | Use “proposal-ready demonstrator” unless production evidence exists | Controlled in proposal pack |
+| Privacy leakage during ingestion | Sensitive data exposure | Local-first framing, no new network calls, recommend data classification before real ingestion | Requires deployment controls |
+| Dataset licensing ambiguity | Reuse or publication risk | Require license and provenance notes for real datasets | Requires partner review |
+| Benchmark contamination | Invalid evaluation results | Separate demo, training, validation, and benchmark artifacts; record transformation history | Requires benchmark-specific protocol |
+| Weak human review | Unchecked claims exported | Review states, admissibility tiers, actor/timestamp audit events | Requires reviewer training |
+| Misuse for papering over poor evidence | False confidence in weak artifacts | Risk flags, rejected/audit-only tiers, explicit limitation notes | Requires governance enforcement |
+| Security or access-control gaps | Unauthorised evidence access | Keep proposal demo synthetic; scope access-control hardening in roadmap | Open engineering item |
+| Materials-science overextension | Synthetic materials records misread as validation | Mark advanced-materials examples as future controlled extensions only | Controlled in proposal demo |
+
+## Ethics position
+
+Fieldgrade should make evidence easier to inspect, not harder. It should preserve disagreement, uncertainty, and review boundaries. It should not convert AI-generated text, speculative technical ideas, or synthetic examples into approved facts without domain review.
+
+## Required operating controls for real pilots
+
+1. Define data owners and reviewers.
+2. Set admissibility-tier policy before ingestion.
+3. Label AI-assisted content.
+4. Keep sensitive records local unless a partner approves transfer.
+5. Record source licenses and reuse constraints.
+6. Export limitations alongside proof packs.
+7. Review security and privacy controls before using real operational or research data.

--- a/docs/proposal/FIELDGRADE_TECHNICAL_ARCHITECTURE.md
+++ b/docs/proposal/FIELDGRADE_TECHNICAL_ARCHITECTURE.md
@@ -1,0 +1,54 @@
+# Fieldgrade Technical Architecture
+
+## Repository-grounded architecture
+
+Fieldgrade is a Python monorepo with three primary implementation areas:
+
+- `termite_fieldpack/` — evidence ingestion, content-addressed storage, provenance events, deterministic bundle sealing, verification, and replay.
+- `mite_ecology/` — review and analysis workflows, deterministic graph operations, import modes, review queue actions, and export support.
+- `fieldgrade_ui/` — FastAPI-based governance workspace and API shell for jobs, registries, governance records, runtime readiness, architecture views, and local UI operation.
+
+The root `pyproject.toml` defines a workspace that depends on the three local packages. The root `Makefile` exposes `make test`, which installs the workspace with `uv` and runs `pytest`.
+
+## Runtime entry points
+
+- Root demo: `./run_demo.sh` on Linux or WSL and `./run_demo.ps1` on Windows.
+- UI/API: `python -m fieldgrade_ui` or the `fieldgrade-ui` console script after installation.
+- Termite CLI: `./termite_fieldpack/bin/termite` or installed `termite` entry point.
+- mite_ecology CLI: `./mite_ecology/bin/mite-ecology` or installed `mite-ecology` entry point.
+- Proposal validation: `python scripts/check_proposal_readiness.py`.
+
+## Data flow
+
+1. Source artifacts are ingested into local evidence storage.
+2. Provenance and content hashes are recorded.
+3. Bundles can be sealed and verified.
+4. Review modes distinguish automatic merge, review-only, quarantine, and refusal paths in the underlying workflow.
+5. Fieldgrade UI/API exposes governance and readiness surfaces.
+6. Proposal demo assets model sources, annotations, audit events, and export manifests as synthetic JSON.
+
+## Local-first boundary
+
+The proposal pack does not add network calls, credentials, external services, or hosted dependencies. The synthetic demo data can be reviewed offline. The existing codebase supports optional local or OpenAI-compatible LLM runtime ownership, but proposal documents treat live LLM output as exogenous unless cached and reviewed.
+
+## Evidence model used in the proposal demo
+
+Each demo object carries:
+
+- object ID,
+- title,
+- source type,
+- provenance note,
+- ingestion timestamp,
+- claim status,
+- admissibility tier,
+- review state,
+- evidence status,
+- review status,
+- risk flags,
+- human-readable explanation, and
+- export hash in the generated manifest.
+
+## Current technical limitation
+
+This proposal pack is documentation, synthetic data, and validation tooling layered on top of the existing repo. It does not turn Fieldgrade into a production-certified platform. Partner-specific data schemas, access controls, screenshot capture, packaging polish, and user acceptance testing remain next-step work.

--- a/docs/proposal/README_PROPOSAL_PACK.md
+++ b/docs/proposal/README_PROPOSAL_PACK.md
@@ -1,0 +1,32 @@
+# Fieldgrade Proposal Pack
+
+This folder contains the funder-facing Fieldgrade proposal-readiness pack. It frames Fieldgrade as a proposal-ready demonstrator for evidence-governed frontier-AI research workflows, while keeping claims grounded in the repository's existing local-first evidence, provenance, review, and export capabilities.
+
+## Contents
+
+- `FIELDGRADE_ONE_PAGE_SUMMARY.md` — concise funder summary.
+- `FIELDGRADE_PROPOSAL_NARRATIVE.md` — problem, solution, innovation, users, delivery plan, and funding fit.
+- `FIELDGRADE_TECHNICAL_ARCHITECTURE.md` — repository-grounded runtime and architecture overview.
+- `FIELDGRADE_DEMO_SCRIPT.md` — walkthrough for the synthetic proposal demo.
+- `FIELDGRADE_FUNDING_FIT_MATRIX.md` — priority funding routes and evidence needed.
+- `FIELDGRADE_RISK_ETHICS_REGISTER.md` — risks, controls, and mitigations.
+- `FIELDGRADE_DATA_GOVERNANCE.md` — provenance, privacy, licensing, and review practices.
+- `FIELDGRADE_12_WEEK_ROADMAP.md` — scoped delivery plan for a proposal sprint.
+- `FIELDGRADE_PARTNER_BRIEF.md` — collaboration brief for universities, RTOs, SMEs, and demonstrator partners.
+- `FIELDGRADE_READINESS_AUDIT.md` — current audit of repo state, commands, gaps, and readiness score.
+
+## Demo and validation assets
+
+Synthetic demo data lives under `data/demo/`. The output-pack landing file is `outputs/proposal_pack/README.md`.
+
+Run the proposal readiness check from the repository root:
+
+```bash
+python scripts/check_proposal_readiness.py
+```
+
+Refresh the demo export manifest after editing demo JSON:
+
+```bash
+python scripts/generate_demo_manifest.py
+```

--- a/outputs/proposal_pack/README.md
+++ b/outputs/proposal_pack/README.md
@@ -1,0 +1,19 @@
+# Fieldgrade Proposal Pack Output
+
+This directory is the landing area for proposal-pack outputs such as screenshots, generated evidence bundles, reviewer notes, or exported proposal appendices.
+
+Current proposal-readiness assets are stored in source-controlled locations:
+
+- proposal documents: `docs/proposal/`,
+- synthetic demo data: `data/demo/`,
+- validation scripts: `scripts/`,
+- generated demo manifest: `data/demo/fieldgrade_demo_export_manifest.json`.
+
+To refresh and validate the current pack:
+
+```bash
+python scripts/generate_demo_manifest.py
+python scripts/check_proposal_readiness.py
+```
+
+All current demo records are synthetic and must not be represented as real benchmark, lab, or operational data.

--- a/resources/mite_componentry_manifest_from_prompt_cache.jsonl
+++ b/resources/mite_componentry_manifest_from_prompt_cache.jsonl
@@ -1,0 +1,1 @@
+{"record_id":"FG-RESOURCE-001","title":"Synthetic Fieldgrade demo resource","source_type":"synthetic_jsonl","provenance_note":"Small public synthetic resource used by run_demo.sh so the local demo has an ingestible second artifact.","created_at":"2026-05-15T00:00:00Z"}

--- a/scripts/check_proposal_readiness.py
+++ b/scripts/check_proposal_readiness.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Check Fieldgrade proposal-readiness artifacts."""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_PROPOSAL_FILES = [
+    "docs/proposal/FIELDGRADE_READINESS_AUDIT.md",
+    "docs/proposal/FIELDGRADE_PROPOSAL_NARRATIVE.md",
+    "docs/proposal/FIELDGRADE_TECHNICAL_ARCHITECTURE.md",
+    "docs/proposal/FIELDGRADE_DEMO_SCRIPT.md",
+    "docs/proposal/FIELDGRADE_FUNDING_FIT_MATRIX.md",
+    "docs/proposal/FIELDGRADE_RISK_ETHICS_REGISTER.md",
+    "docs/proposal/FIELDGRADE_DATA_GOVERNANCE.md",
+    "docs/proposal/FIELDGRADE_12_WEEK_ROADMAP.md",
+    "docs/proposal/FIELDGRADE_PARTNER_BRIEF.md",
+    "docs/proposal/FIELDGRADE_ONE_PAGE_SUMMARY.md",
+    "docs/proposal/README_PROPOSAL_PACK.md",
+]
+REQUIRED_DEMO_FILES = [
+    "data/demo/fieldgrade_demo_sources.json",
+    "data/demo/fieldgrade_demo_annotations.json",
+    "data/demo/fieldgrade_demo_audit_trail.json",
+    "data/demo/fieldgrade_demo_export_manifest.json",
+    "outputs/proposal_pack/README.md",
+]
+JSON_DEMO_FILES = [path for path in REQUIRED_DEMO_FILES if path.endswith(".json")]
+REQUIRED_OBJECT_FIELDS = {
+    "object_id",
+    "title",
+    "source_type",
+    "provenance_note",
+    "ingestion_timestamp",
+    "claim_status",
+    "admissibility_tier",
+    "review_state",
+}
+PLACEHOLDER_RE = re.compile(r"\b(TODO|FIXME|TBD)\b|lorem ipsum|\[insert\]", re.IGNORECASE)
+LOCAL_SETUP_RE = re.compile(r"local\s+(setup|demo|run|ui)|setup", re.IGNORECASE)
+
+
+@dataclass
+class Result:
+    missing_files: list[str] = field(default_factory=list)
+    invalid_json_files: list[str] = field(default_factory=list)
+    missing_object_fields: list[str] = field(default_factory=list)
+    placeholder_findings: list[str] = field(default_factory=list)
+    readme_findings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not any(
+            [
+                self.missing_files,
+                self.invalid_json_files,
+                self.missing_object_fields,
+                self.placeholder_findings,
+                self.readme_findings,
+            ]
+        )
+
+
+def load_json(path: Path, result: Result) -> Any | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - produce reviewer-friendly diagnostics
+        result.invalid_json_files.append(f"{path.relative_to(ROOT)}: {exc}")
+        return None
+
+
+def iter_manifest_objects(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        objects = payload.get("objects", [])
+        if isinstance(objects, list):
+            return [item for item in objects if isinstance(item, dict)]
+    return []
+
+
+def check_files(result: Result) -> None:
+    for rel in REQUIRED_PROPOSAL_FILES + REQUIRED_DEMO_FILES:
+        if not (ROOT / rel).is_file():
+            result.missing_files.append(rel)
+
+
+def check_json(result: Result) -> None:
+    for rel in JSON_DEMO_FILES:
+        path = ROOT / rel
+        if not path.exists():
+            continue
+        payload = load_json(path, result)
+        if payload is None:
+            continue
+        if rel.endswith("fieldgrade_demo_sources.json"):
+            if not isinstance(payload, list):
+                result.invalid_json_files.append(f"{rel}: expected a list of source objects")
+                continue
+            for index, item in enumerate(payload):
+                if not isinstance(item, dict):
+                    result.missing_object_fields.append(f"{rel}[{index}]: expected object")
+                    continue
+                missing = sorted(REQUIRED_OBJECT_FIELDS - set(item))
+                if missing:
+                    result.missing_object_fields.append(f"{rel}[{index}] {item.get('object_id', '<unknown>')}: {', '.join(missing)}")
+        if rel.endswith("fieldgrade_demo_export_manifest.json"):
+            for index, item in enumerate(iter_manifest_objects(payload)):
+                missing = sorted(REQUIRED_OBJECT_FIELDS - set(item))
+                if missing:
+                    result.missing_object_fields.append(
+                        f"{rel}.objects[{index}] {item.get('object_id', '<unknown>')}: {', '.join(missing)}"
+                    )
+
+
+def check_placeholders(result: Result) -> None:
+    scan_files = [ROOT / rel for rel in REQUIRED_PROPOSAL_FILES]
+    scan_files += [ROOT / rel for rel in REQUIRED_DEMO_FILES if rel.endswith((".md", ".json"))]
+    for path in scan_files:
+        if not path.exists():
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if PLACEHOLDER_RE.search(line):
+                result.placeholder_findings.append(f"{path.relative_to(ROOT)}:{lineno}: {line.strip()}")
+
+
+def check_readme(result: Result) -> None:
+    readme = ROOT / "README.md"
+    if not readme.exists():
+        result.readme_findings.append("README.md is missing")
+        return
+    text = readme.read_text(encoding="utf-8")
+    if not LOCAL_SETUP_RE.search(text):
+        result.readme_findings.append("README.md does not contain a recognizable local setup/run section")
+
+
+def readiness_score(result: Result) -> int:
+    total_checks = 5
+    passed = total_checks - sum(
+        bool(category)
+        for category in [
+            result.missing_files,
+            result.invalid_json_files,
+            result.missing_object_fields,
+            result.placeholder_findings,
+            result.readme_findings,
+        ]
+    )
+    return round((passed / total_checks) * 100)
+
+
+def print_list(title: str, values: list[str]) -> None:
+    print(f"{title}:")
+    if not values:
+        print("  none")
+    else:
+        for value in values:
+            print(f"  - {value}")
+
+
+def main() -> int:
+    result = Result()
+    check_files(result)
+    check_json(result)
+    check_placeholders(result)
+    check_readme(result)
+
+    status = "PASS" if result.ok else "FAIL"
+    print(f"Fieldgrade proposal readiness status: {status}")
+    print(f"Readiness score: {readiness_score(result)}/100")
+    print_list("Missing files", result.missing_files)
+    print_list("Invalid JSON files", result.invalid_json_files)
+    print_list("Missing demo object fields", result.missing_object_fields)
+    print_list("Placeholder findings", result.placeholder_findings)
+    print_list("README findings", result.readme_findings)
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_demo_manifest.py
+++ b/scripts/generate_demo_manifest.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Generate the synthetic Fieldgrade demo export manifest.
+
+The script is intentionally dependency-free so proposal reviewers can run it in a
+plain Python 3.10+ environment.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEMO_DIR = ROOT / "data" / "demo"
+SOURCES = DEMO_DIR / "fieldgrade_demo_sources.json"
+ANNOTATIONS = DEMO_DIR / "fieldgrade_demo_annotations.json"
+AUDIT_TRAIL = DEMO_DIR / "fieldgrade_demo_audit_trail.json"
+MANIFEST = DEMO_DIR / "fieldgrade_demo_export_manifest.json"
+DEMO_FILES = [SOURCES, ANNOTATIONS, AUDIT_TRAIL]
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_hash(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    sources = load_json(SOURCES)
+    annotations = load_json(ANNOTATIONS)
+    audit_trail = load_json(AUDIT_TRAIL)
+
+    annotations_by_object: dict[str, list[dict[str, Any]]] = {}
+    for annotation in annotations:
+        annotations_by_object.setdefault(annotation["object_id"], []).append(annotation)
+
+    events_by_object: dict[str, list[dict[str, Any]]] = {}
+    for event in audit_trail:
+        events_by_object.setdefault(event["object_id"], []).append(event)
+
+    objects: list[dict[str, Any]] = []
+    for source in sources:
+        object_id = source["object_id"]
+        object_record = {
+            "object_id": object_id,
+            "title": source["title"],
+            "source_type": source["source_type"],
+            "provenance_note": source["provenance_note"],
+            "ingestion_timestamp": source["ingestion_timestamp"],
+            "claim_status": source["claim_status"],
+            "admissibility_tier": source["admissibility_tier"],
+            "review_state": source["review_state"],
+            "evidence_status": source.get("evidence_status", "synthetic_demo"),
+            "review_status": source.get("review_status", "unknown"),
+            "annotation_count": len(annotations_by_object.get(object_id, [])),
+            "audit_event_count": len(events_by_object.get(object_id, [])),
+            "export_hash": canonical_hash(
+                {
+                    "source": source,
+                    "annotations": annotations_by_object.get(object_id, []),
+                    "audit_events": events_by_object.get(object_id, []),
+                }
+            ),
+            "human_readable_explanation": source["human_readable_explanation"],
+        }
+        objects.append(object_record)
+
+    manifest = {
+        "manifest_id": "FG-DEMO-MANIFEST-2026-05-15",
+        "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "created_by": "scripts/generate_demo_manifest.py",
+        "bundle_title": "Fieldgrade proposal-readiness synthetic evidence bundle",
+        "bundle_scope": "Proposal-ready demonstrator for evidence-governed frontier-AI research workflows.",
+        "synthetic_data_notice": (
+            "All objects in this manifest are synthetic proposal-demo records and must not be represented "
+            "as real benchmark, lab, or operational data."
+        ),
+        "objects": objects,
+        "files": [
+            {
+                "path": str(path.relative_to(ROOT)),
+                "sha256": sha256_file(path),
+                "bytes": path.stat().st_size,
+            }
+            for path in DEMO_FILES
+        ],
+    }
+
+    MANIFEST.write_text(json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    print(f"Wrote {MANIFEST.relative_to(ROOT)} with {len(objects)} objects")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_fieldgrade_pack.py
+++ b/scripts/validate_fieldgrade_pack.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper for proposal-pack validation."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    return subprocess.call([sys.executable, str(ROOT / "scripts" / "check_proposal_readiness.py")], cwd=ROOT)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a concrete, repo-grounded proposal-readiness pack so Fieldgrade can be evaluated as a funder-facing demonstrator for evidence-governed frontier-AI workflows. 
- Supply synthetic demo data and lightweight validation so reviewers can inspect export manifests, provenance fields, admissibility tiers, and human-review controls without requiring networked services. 
- Capture the expected Codex/Codex-agent workflow in `AGENTS.md` so future work follows a repeatable plan and verification rubric. 
- Keep changes small and non-invasive by adding documentation, demo assets, and dependency-free scripts rather than modifying runtime code.

### Description
- Add root `AGENTS.md` with the proposal-readiness instructions, verification rules, admissibility tiers, review-state vocabulary, and required artifacts list. 
- Add a proposal pack under `docs/proposal/` including `FIELDGRADE_READINESS_AUDIT.md`, `FIELDGRADE_PROPOSAL_NARRATIVE.md`, `FIELDGRADE_TECHNICAL_ARCHITECTURE.md`, `FIELDGRADE_DEMO_SCRIPT.md`, `FIELDGRADE_FUNDING_FIT_MATRIX.md`, `FIELDGRADE_RISK_ETHICS_REGISTER.md`, `FIELDGRADE_DATA_GOVERNANCE.md`, `FIELDGRADE_12_WEEK_ROADMAP.md`, `FIELDGRADE_PARTNER_BRIEF.md`, `FIELDGRADE_ONE_PAGE_SUMMARY.md`, and `README_PROPOSAL_PACK.md`. 
- Add synthetic demo data under `data/demo/` and an export manifest generator `scripts/generate_demo_manifest.py`, plus validation tooling `scripts/check_proposal_readiness.py` and a wrapper `scripts/validate_fieldgrade_pack.py`. 
- Update `README.md` with a short local-setup section pointing to the demo data and validation commands and add an outputs landing `outputs/proposal_pack/README.md` and a tiny ingestible resource used by the existing demo script.

### Testing
- Ran `python scripts/generate_demo_manifest.py` which successfully wrote `data/demo/fieldgrade_demo_export_manifest.json` and returned success. 
- Ran `python scripts/check_proposal_readiness.py` (and via `scripts/validate_fieldgrade_pack.py`) which returned `PASS` and a readiness score of `100/100` with no missing files, invalid JSON, placeholder findings, or README issues. 
- Verified the new scripts compile with `python -m py_compile` and performed a syntax-only check of `run_demo.sh` and other demo scripts (`bash -n`) which reported no syntax errors. 
- Noted two environment-limited test failures: `python -m pytest -q` aborted during collection because `httpx` is not installed in the ambient environment, and `make test` could not complete because `pip`/package index access failed when attempting to fetch `uv` (package index returned a `403`), so full test-suite execution was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07348bec048333acc8bed65f7dd363)

## Summary by Sourcery

Add a proposal-readiness demonstrator pack for Fieldgrade, including documentation, synthetic demo data, and validation scripts to support funder and RFP review.

New Features:
- Introduce a proposal-readiness documentation pack describing Fieldgrade’s architecture, roadmap, risks, funding fit, and partner briefing for use in funding proposals.
- Add synthetic demo evidence records and an export manifest to illustrate Fieldgrade’s evidence, provenance, and review workflow without relying on real data.
- Provide CLI scripts to generate the demo export manifest and validate the completeness and quality of the proposal pack and demo assets.

Enhancements:
- Extend the main README with local setup and validation instructions for the proposal-ready demonstrator, including CLI and UI run paths.
- Add an outputs landing directory for proposal-pack artifacts and a small ingestible resource referenced by the existing demo flow.

Documentation:
- Create AGENTS.md to define proposal-readiness goals, required artifacts, governance rules, and verification steps for working on Fieldgrade as a demonstrator.
- Document the proposal demo’s narrative, technical architecture, demo script, data governance, risk and ethics register, funding-fit matrix, 12-week roadmap, partner brief, and one-page summary under docs/proposal/.